### PR TITLE
chore: added npm publish provenance to gh action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,10 @@ jobs:
         run: yarn prepack
   
       - name: Publish to npm
-        run: yarn publish --non-interactive --provenance --access public
+        run: |
+          npm install -g npm
+          npm ci
+          npm publish --non-interactive --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         


### PR DESCRIPTION
- chore: added npm publish provenance to gh action