### PR TITLE
chore: used yarn install instead of npm ci as the yarn lock file is already present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
   
       - name: Publish to npm
         run: |
-          npm ci
+          yarn install --frozen-lockfile
           npm publish --non-interactive --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- chore: used yarn install instead of npm ci as the yarn lock file is already present