### PR TITLE
feat!: drag-and-drop reordering for tree nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Make sure to follow the native-related installation instructions for these depen
 - 🌳 **Multi-Level Selection**: Select individual nodes or entire branches with ease.
 - 📦 **Supports Large Datasets**: Efficiently handles large trees without much performance degradation.
 - 🔒 **TypeScript Support**: Full TypeScript support for better developer experience.
+- 🔀 **Drag-and-Drop**: Long-press to drag nodes and reorder or nest them anywhere in the tree.
 - 💻 **Cross-Platform**: Works seamlessly across iOS, Android, and web (with React Native Web).
 
 ## Usage
@@ -112,6 +113,46 @@ export function TreeViewUsageExample(){
 }
 ```
 
+### Drag-and-Drop Usage
+
+```tsx
+import {
+  TreeView,
+  type TreeNode,
+  type TreeViewRef,
+  type DragEndEvent
+} from 'react-native-tree-multi-select';
+
+const myData: TreeNode[] = [...];
+
+export function DragDropExample(){
+  const [data, setData] = React.useState<TreeNode[]>(myData);
+  const treeViewRef = React.useRef<TreeViewRef | null>(null);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    // event.newTreeData contains the reordered tree — just set it
+    setData(event.newTreeData);
+  };
+
+  return(
+    <TreeView
+      ref={treeViewRef}
+      data={data}
+      onCheck={(checked, indeterminate) => { /* ... */ }}
+      onExpand={(expanded) => { /* ... */ }}
+      dragEnabled={true}
+      onDragEnd={handleDragEnd}
+    />
+  );
+}
+```
+
+Long-press a node to start dragging. Drag over other nodes to see drop indicators. Drop above/below to reorder as siblings, or drop inside a parent node to nest it. The tree auto-scrolls when dragging near the edges.
+
+For visual customizations (overlay styles, indicator colors, or fully custom components), see the [`dragDropCustomizations`](#dragdropcustomizationsid) prop.
+
+---
+
 ### Properties
 
 #### TreeViewProps`<ID = string>`
@@ -134,6 +175,14 @@ export function TreeViewUsageExample(){
 | `ExpandCollapseIconComponent`      | `ComponentType<`[ExpandIconProps](#expandiconprops)`>`       | No       | A custom expand/collapse icon component                      |
 | `ExpandCollapseTouchableComponent` | `ComponentType<`[TouchableOpacityProps](https://reactnative.dev/docs/touchableopacity#props)`>` | No       | A custom expand/collapse touchable component                 |
 | `CustomNodeRowComponent`           | `React.ComponentType<`[NodeRowProps](#noderowpropsid--string)`<ID>>` | No       | Custom row item component                                    |
+| `dragEnabled`                      | `boolean`                                                    | No       | Enable drag-and-drop reordering                              |
+| `onDragEnd`                        | `(event: `[DragEndEvent](#dragendeventid--string)`<ID>) => void` | No       | Callback fired after a node is dropped at a new position     |
+| `longPressDuration`                | `number`                                                     | No       | Long press duration in ms to start drag (default: 400)       |
+| `autoScrollThreshold`              | `number`                                                     | No       | Distance from edge (px) to trigger auto-scroll (default: 60) |
+| `autoScrollSpeed`                  | `number`                                                     | No       | Speed multiplier for auto-scroll (default: 1.0)              |
+| `dragOverlayOffset`                | `number`                                                     | No       | Overlay offset from the finger, in item-height units (default: -1, i.e. one row above finger) |
+| `autoExpandDelay`                  | `number`                                                     | No       | Delay in ms before auto-expanding a collapsed node during drag hover (default: 800) |
+| `dragDropCustomizations`           | [DragDropCustomizations](#dragdropcustomizationsid)`<ID>`    | No       | Customizations for drag-and-drop visuals (overlay, indicator, opacity) |
 
 ##### Notes
 
@@ -262,6 +311,107 @@ Type: `boolean` OR `"indeterminate"`
 | `isExpanded`   | `boolean`                               | Yes      | Whether the node is expanded or not                     |
 | `onCheck`      | `() => void`                            | Yes      | Function to be called when the checkbox is pressed      |
 | `onExpand`     | `() => void`                            | Yes      | Function to be called when the expand button is pressed |
+| `isDragTarget` | `boolean`                               | No       | Whether this node is the current drop target during drag |
+| `isDragging`   | `boolean`                               | No       | Whether a drag operation is in progress                  |
+| `isDraggedNode`| `boolean`                               | No       | Whether this node is the one being dragged               |
+
+---
+
+#### DragEndEvent`<ID = string>`
+
+*The event object passed to the `onDragEnd` callback after a successful drop.*
+
+| Property        | Type                                    | Description                                                  |
+| --------------- | --------------------------------------- | ------------------------------------------------------------ |
+| `draggedNodeId` | `ID`                                    | The id of the node that was dragged                          |
+| `targetNodeId`  | `ID`                                    | The id of the target node where the dragged node was dropped |
+| `position`      | [DropPosition](#dropposition)           | Where relative to the target: `above`/`below` = sibling, `inside` = child |
+| `newTreeData`   | `TreeNode<ID>[]`                        | The reordered tree data after the move                       |
+
+#### DropPosition
+
+Type: `"above"` | `"below"` | `"inside"`
+
+---
+
+#### DragDropCustomizations`<ID>`
+
+*Customizations for drag-and-drop visuals.*
+
+| Property                       | Type                                                                                  | Required | Description                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
+| `draggedNodeOpacity`           | `number`                                                                              | No       | Opacity of the dragged node and invalid targets (default: 0.3)    |
+| `dropIndicatorStyleProps`      | [DropIndicatorStyleProps](#dropindicatorstyleprops)                                    | No       | Style props for the built-in drop indicator                       |
+| `dragOverlayStyleProps`        | [DragOverlayStyleProps](#dragoverlaystyleprops)                                       | No       | Style props for the drag overlay (lifted node ghost)              |
+| `CustomDropIndicatorComponent` | `ComponentType<`[DropIndicatorComponentProps](#dropindicatorcomponentprops)`>`         | No       | Fully custom drop indicator component                             |
+| `CustomDragOverlayComponent`   | `ComponentType<`[DragOverlayComponentProps](#dragoverlaycomponentpropsid--string)`<ID>>`| No       | Fully custom drag overlay component                               |
+
+---
+
+#### DropIndicatorStyleProps
+
+*Style props for customizing the built-in drop indicator appearance.*
+
+| Property              | Type     | Required | Description                                                    |
+| --------------------- | -------- | -------- | -------------------------------------------------------------- |
+| `lineColor`           | `string` | No       | Color of the line indicator for above/below (default: `"#0078FF"`) |
+| `lineThickness`       | `number` | No       | Thickness of the line indicator (default: 3)                   |
+| `circleSize`          | `number` | No       | Diameter of the circle at the line's start (default: 10)       |
+| `highlightColor`      | `string` | No       | Background color of the "inside" highlight (default: `"rgba(0, 120, 255, 0.15)"`) |
+| `highlightBorderColor`| `string` | No       | Border color of the "inside" highlight (default: `"rgba(0, 120, 255, 0.5)"`) |
+
+---
+
+#### DragOverlayStyleProps
+
+*Style props for customizing the drag overlay (the "lifted" node ghost).*
+
+| Property        | Type                   | Required | Description                                      |
+| --------------- | ---------------------- | -------- | ------------------------------------------------ |
+| `backgroundColor`| `string`              | No       | Background color (default: `"rgba(255, 255, 255, 0.95)"`) |
+| `shadowColor`   | `string`               | No       | Shadow color (default: `"#000"`)                 |
+| `shadowOpacity` | `number`               | No       | Shadow opacity (default: 0.25)                   |
+| `shadowRadius`  | `number`               | No       | Shadow radius (default: 4)                       |
+| `elevation`     | `number`               | No       | Android elevation (default: 10)                  |
+| `style`         | `StyleProp<ViewStyle>` | No       | Custom style applied to the overlay container    |
+
+---
+
+#### DropIndicatorComponentProps
+
+*Props passed to a custom drop indicator component (when using `CustomDropIndicatorComponent`).*
+
+| Property   | Type                          | Required | Description                                                  |
+| ---------- | ----------------------------- | -------- | ------------------------------------------------------------ |
+| `position` | [DropPosition](#dropposition) | Yes      | Whether the indicator is above, below, or inside the target  |
+
+---
+
+#### DragOverlayComponentProps`<ID = string>`
+
+*Props passed to a custom drag overlay component (when using `CustomDragOverlayComponent`).*
+
+| Property | Type            | Required | Description                    |
+| -------- | --------------- | -------- | ------------------------------ |
+| `node`   | `TreeNode<ID>`  | Yes      | The node being dragged         |
+| `level`  | `number`        | Yes      | The nesting level of the node  |
+
+---
+
+### Exported Utilities
+
+#### `moveTreeNode`
+
+```typescript
+moveTreeNode<ID>(
+  data: TreeNode<ID>[],
+  draggedNodeId: ID,
+  targetNodeId: ID,
+  position: DropPosition
+): TreeNode<ID>[]
+```
+
+Moves a node within a tree structure. Returns a new tree (no mutation). Useful if you want to perform tree moves manually outside of the `onDragEnd` callback.
 
 ---
 
@@ -274,6 +424,7 @@ Type: `boolean` OR `"indeterminate"`
 - [x] Ref function to programatically expand/collapse a certain node 
 - [x] Ref function to programatically un/check a certain node
 - [x] Ref function to auto-scroll to a certain node's position - available in 1.9.0+
+- [x] Drag-and-drop reordering with customizable visuals
 
 If you do not see what you want in the planned feature list, raise a feature request. 
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -17,6 +17,10 @@ import packageJson from "../../package.json";
 import { TwoTreeViewsScreen } from "./screens/TwoTreeViewsScreen";
 import CustomNodeID from "./screens/CustomNodeIDScreen";
 import ControlsDemoScreen from "./screens/ControlsDemoScreen";
+import DragDropScreen from "./screens/DragDropScreen";
+import DragDropStyledScreen from "./screens/DragDropStyledScreen";
+import DragDropCustomOverlayScreen from "./screens/DragDropCustomOverlayScreen";
+import DragDropCustomRowScreen from "./screens/DragDropCustomRowScreen";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 const data: ShowcaseExampleScreenSectionType[] = [
@@ -87,6 +91,31 @@ const data: ShowcaseExampleScreenSectionType[] = [
         name: "Neither to children nor to parents",
         slug: "neither-children-nor-parent",
         getScreen: () => NeitherToChildrenNorToParentSmallDataScreen,
+      },
+    ],
+  },
+  {
+    title: "Drag & Drop",
+    data: [
+      {
+        name: "Basic",
+        slug: "drag-drop",
+        getScreen: () => DragDropScreen,
+      },
+      {
+        name: "Styled Indicators",
+        slug: "drag-drop-styled",
+        getScreen: () => DragDropStyledScreen,
+      },
+      {
+        name: "Custom Components",
+        slug: "drag-drop-custom-overlay",
+        getScreen: () => DragDropCustomOverlayScreen,
+      },
+      {
+        name: "Custom Row + Drag",
+        slug: "drag-drop-custom-row",
+        getScreen: () => DragDropCustomRowScreen,
       },
     ],
   },

--- a/example/src/screens/DragDropCustomOverlayScreen.tsx
+++ b/example/src/screens/DragDropCustomOverlayScreen.tsx
@@ -1,0 +1,264 @@
+import { useRef, useState, useCallback } from "react";
+import {
+    SafeAreaView,
+    View,
+    Text,
+    StyleSheet,
+    Button,
+} from "react-native";
+
+import {
+    TreeView,
+    type TreeViewRef,
+    type TreeNode,
+    type DragEndEvent,
+    type DragOverlayComponentProps,
+    type DropIndicatorComponentProps,
+} from "react-native-tree-multi-select";
+
+import { styles as screenStyles } from "./screens.styles";
+
+const initialData: TreeNode[] = [
+    {
+        id: "inbox",
+        name: "Inbox",
+        children: [
+            { id: "inbox-1", name: "Welcome email" },
+            { id: "inbox-2", name: "Meeting invite" },
+            { id: "inbox-3", name: "Project update" },
+        ],
+    },
+    {
+        id: "work",
+        name: "Work",
+        children: [
+            {
+                id: "work-proj",
+                name: "Projects",
+                children: [
+                    { id: "proj-1", name: "Mobile App v2" },
+                    { id: "proj-2", name: "API Migration" },
+                ],
+            },
+            { id: "work-1", name: "Sprint planning" },
+            { id: "work-2", name: "Code review" },
+        ],
+    },
+    {
+        id: "personal",
+        name: "Personal",
+        children: [
+            { id: "personal-1", name: "Grocery list" },
+            { id: "personal-2", name: "Workout plan" },
+            { id: "personal-3", name: "Book notes" },
+        ],
+    },
+    {
+        id: "archive",
+        name: "Archive",
+        children: [
+            { id: "archive-1", name: "Old reports" },
+            { id: "archive-2", name: "2024 docs" },
+        ],
+    },
+];
+
+function CustomDragOverlay({ node, level }: DragOverlayComponentProps) {
+    return (
+        <View style={overlayStyles.container}>
+            <View style={overlayStyles.iconContainer}>
+                <Text style={overlayStyles.icon}>
+                    {node.children?.length ? "📁" : "📄"}
+                </Text>
+            </View>
+            <View style={overlayStyles.textContainer}>
+                <Text style={overlayStyles.name} numberOfLines={1}>
+                    {node.name}
+                </Text>
+                <Text style={overlayStyles.meta}>
+                    {node.children?.length
+                        ? `${node.children.length} items · Level ${level}`
+                        : `Level ${level}`}
+                </Text>
+            </View>
+            <Text style={overlayStyles.dragIcon}>✦</Text>
+        </View>
+    );
+}
+
+function CustomDropIndicator({ position }: DropIndicatorComponentProps) {
+    if (position === "inside") {
+        return (
+            <View style={indicatorStyles.insideContainer}>
+                <View style={indicatorStyles.insideDot} />
+                <Text style={indicatorStyles.insideText}>Drop here</Text>
+                <View style={indicatorStyles.insideDot} />
+            </View>
+        );
+    }
+
+    return (
+        <View
+            style={[
+                indicatorStyles.lineContainer,
+                position === "above" ? { top: 0 } : { bottom: 0 },
+            ]}
+        >
+            <View style={indicatorStyles.diamond} />
+            <View style={indicatorStyles.line} />
+            <View style={indicatorStyles.diamond} />
+        </View>
+    );
+}
+
+export default function DragDropCustomOverlayScreen() {
+    const [data, setData] = useState<TreeNode[]>(initialData);
+    const treeViewRef = useRef<TreeViewRef | null>(null);
+    const [lastDrop, setLastDrop] = useState("");
+
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        setData(event.newTreeData);
+        setLastDrop(
+            `Moved "${event.draggedNodeId}" ${event.position} "${event.targetNodeId}"`
+        );
+    }, []);
+
+    return (
+        <SafeAreaView style={screenStyles.mainView}>
+            <Text style={localStyles.dropInfo}>
+                {lastDrop || "Custom overlay & drop indicator components"}
+            </Text>
+
+            <View style={screenStyles.selectionButtonRow}>
+                <Button title="Expand All" onPress={() => treeViewRef.current?.expandAll()} />
+                <Button title="Collapse All" onPress={() => treeViewRef.current?.collapseAll()} />
+            </View>
+            <View style={[screenStyles.selectionButtonRow, screenStyles.selectionButtonBottom]}>
+                <Button title="Reset" onPress={() => { setData(initialData); setLastDrop(""); }} />
+            </View>
+
+            <View style={screenStyles.treeViewParent}>
+                <TreeView
+                    ref={treeViewRef}
+                    data={data}
+                    onCheck={() => {}}
+                    onExpand={() => {}}
+                    dragEnabled={true}
+                    onDragEnd={handleDragEnd}
+                    preExpandedIds={["inbox", "work", "personal"]}
+                    longPressDuration={300}
+                    autoExpandDelay={600}
+                    dragDropCustomizations={{
+                        draggedNodeOpacity: 0.2,
+                        CustomDragOverlayComponent: CustomDragOverlay,
+                        CustomDropIndicatorComponent: CustomDropIndicator,
+                    }}
+                />
+            </View>
+        </SafeAreaView>
+    );
+}
+
+const localStyles = StyleSheet.create({
+    dropInfo: {
+        padding: 10,
+        fontSize: 13,
+        color: "#666",
+        textAlign: "center",
+        borderBottomWidth: 0.5,
+        borderColor: "lightgrey",
+    },
+});
+
+const overlayStyles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 14,
+        paddingVertical: 10,
+        backgroundColor: "#1a1a2e",
+        borderRadius: 10,
+        marginHorizontal: 4,
+    },
+    iconContainer: {
+        width: 36,
+        height: 36,
+        borderRadius: 8,
+        backgroundColor: "rgba(255,255,255,0.1)",
+        alignItems: "center",
+        justifyContent: "center",
+        marginRight: 10,
+    },
+    icon: {
+        fontSize: 18,
+    },
+    textContainer: {
+        flex: 1,
+    },
+    name: {
+        color: "#fff",
+        fontSize: 15,
+        fontWeight: "600",
+    },
+    meta: {
+        color: "rgba(255,255,255,0.5)",
+        fontSize: 11,
+        marginTop: 2,
+    },
+    dragIcon: {
+        color: "#6c63ff",
+        fontSize: 18,
+        marginLeft: 8,
+    },
+});
+
+const indicatorStyles = StyleSheet.create({
+    lineContainer: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        flexDirection: "row",
+        alignItems: "center",
+        height: 3,
+        zIndex: 10,
+    },
+    line: {
+        flex: 1,
+        height: 2,
+        backgroundColor: "#6c63ff",
+    },
+    diamond: {
+        width: 8,
+        height: 8,
+        backgroundColor: "#6c63ff",
+        transform: [{ rotate: "45deg" }],
+    },
+    insideContainer: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: "rgba(108, 99, 255, 0.08)",
+        borderWidth: 1.5,
+        borderColor: "rgba(108, 99, 255, 0.4)",
+        borderRadius: 6,
+        borderStyle: "dashed",
+        zIndex: 10,
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    insideDot: {
+        width: 4,
+        height: 4,
+        borderRadius: 2,
+        backgroundColor: "#6c63ff",
+        marginHorizontal: 6,
+    },
+    insideText: {
+        color: "#6c63ff",
+        fontSize: 11,
+        fontWeight: "600",
+    },
+});

--- a/example/src/screens/DragDropCustomOverlayScreen.tsx
+++ b/example/src/screens/DragDropCustomOverlayScreen.tsx
@@ -101,7 +101,7 @@ function CustomDropIndicator({ position }: DropIndicatorComponentProps) {
         <View
             style={[
                 indicatorStyles.lineContainer,
-                position === "above" ? { top: 0 } : { bottom: 0 },
+                position === "above" ? indicatorStyles.lineTop : indicatorStyles.lineBottom,
             ]}
         >
             <View style={indicatorStyles.diamond} />
@@ -232,6 +232,12 @@ const indicatorStyles = StyleSheet.create({
         height: 8,
         backgroundColor: "#6c63ff",
         transform: [{ rotate: "45deg" }],
+    },
+    lineTop: {
+        top: 0,
+    },
+    lineBottom: {
+        bottom: 0,
     },
     insideContainer: {
         position: "absolute",

--- a/example/src/screens/DragDropCustomRowScreen.tsx
+++ b/example/src/screens/DragDropCustomRowScreen.tsx
@@ -79,6 +79,7 @@ const avatarColors = [
 
 function getColor(id: string): string {
     let hash = 0;
+    // eslint-disable-next-line no-bitwise
     for (let i = 0; i < id.length; i++) hash = id.charCodeAt(i) + ((hash << 5) - hash);
     return avatarColors[Math.abs(hash) % avatarColors.length]!;
 }

--- a/example/src/screens/DragDropCustomRowScreen.tsx
+++ b/example/src/screens/DragDropCustomRowScreen.tsx
@@ -1,0 +1,320 @@
+import { useRef, useState, useCallback, memo } from "react";
+import {
+    SafeAreaView,
+    View,
+    Text,
+    StyleSheet,
+    Button,
+    TouchableOpacity,
+} from "react-native";
+
+import {
+    TreeView,
+    type TreeViewRef,
+    type TreeNode,
+    type DragEndEvent,
+    type NodeRowProps,
+} from "react-native-tree-multi-select";
+
+import { styles as screenStyles } from "./screens.styles";
+
+const initialData: TreeNode[] = [
+    {
+        id: "team",
+        name: "Engineering Team",
+        children: [
+            {
+                id: "frontend",
+                name: "Frontend",
+                children: [
+                    { id: "fe-1", name: "Alice Chen" },
+                    { id: "fe-2", name: "Bob Park" },
+                    { id: "fe-3", name: "Carol Liu" },
+                ],
+            },
+            {
+                id: "backend",
+                name: "Backend",
+                children: [
+                    { id: "be-1", name: "Dave Kim" },
+                    { id: "be-2", name: "Eve Santos" },
+                ],
+            },
+            {
+                id: "devops",
+                name: "DevOps",
+                children: [
+                    { id: "do-1", name: "Frank Lee" },
+                ],
+            },
+        ],
+    },
+    {
+        id: "design",
+        name: "Design Team",
+        children: [
+            { id: "d-1", name: "Grace Wang" },
+            { id: "d-2", name: "Henry Zhao" },
+        ],
+    },
+    {
+        id: "pm",
+        name: "Product",
+        children: [
+            { id: "pm-1", name: "Iris Patel" },
+            { id: "pm-2", name: "Jack Moreno" },
+        ],
+    },
+];
+
+function getInitials(name: string): string {
+    return name.split(" ").map(w => w[0]).join("").slice(0, 2).toUpperCase();
+}
+
+const avatarColors = [
+    "#FF6B6B", "#4ECDC4", "#45B7D1", "#96CEB4",
+    "#FFEAA7", "#DDA0DD", "#98D8C8", "#F7DC6F",
+    "#BB8FCE", "#85C1E9", "#F0B27A", "#82E0AA",
+];
+
+function getColor(id: string): string {
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) hash = id.charCodeAt(i) + ((hash << 5) - hash);
+    return avatarColors[Math.abs(hash) % avatarColors.length]!;
+}
+
+const TeamNodeRow = memo(_TeamNodeRow) as typeof _TeamNodeRow;
+function _TeamNodeRow<ID = string>(props: NodeRowProps<ID>) {
+    const { node, level, checkedValue, isExpanded, onCheck, onExpand,
+        isDragging, isDraggedNode, isDragTarget } = props;
+
+    const isLeaf = !node.children?.length;
+    const isChecked = checkedValue === true;
+    const isIndeterminate = checkedValue === "indeterminate";
+
+    const rowOpacity = isDragging && (isDraggedNode || isDragTarget) ? 0.3 : 1;
+
+    return (
+        <TouchableOpacity
+            activeOpacity={0.7}
+            onPress={onCheck}
+            style={[
+                rowStyles.row,
+                { paddingLeft: 12 + level * 20, opacity: rowOpacity },
+                isChecked && rowStyles.rowChecked,
+            ]}
+        >
+            {isLeaf ? (
+                <View style={[rowStyles.avatar, { backgroundColor: getColor(String(node.id)) }]}>
+                    <Text style={rowStyles.avatarText}>{getInitials(node.name)}</Text>
+                </View>
+            ) : (
+                <View style={[rowStyles.folderIcon, isChecked && rowStyles.folderIconChecked]}>
+                    <Text style={rowStyles.folderEmoji}>
+                        {isExpanded ? "📂" : "📁"}
+                    </Text>
+                </View>
+            )}
+
+            <View style={rowStyles.textContainer}>
+                <Text style={[
+                    rowStyles.name,
+                    isChecked && rowStyles.nameChecked,
+                ]} numberOfLines={1}>
+                    {node.name}
+                </Text>
+                {!isLeaf && (
+                    <Text style={rowStyles.subtitle}>
+                        {node.children!.length} member{node.children!.length !== 1 ? "s" : ""}
+                        {isIndeterminate ? " · Partial" : isChecked ? " · All selected" : ""}
+                    </Text>
+                )}
+            </View>
+
+            {/* Checkbox indicator */}
+            <View style={[
+                rowStyles.checkbox,
+                isChecked && rowStyles.checkboxChecked,
+                isIndeterminate && rowStyles.checkboxIndeterminate,
+            ]}>
+                {isChecked && <Text style={rowStyles.checkmark}>✓</Text>}
+                {isIndeterminate && <Text style={rowStyles.dash}>−</Text>}
+            </View>
+
+            {!isLeaf && (
+                <TouchableOpacity onPress={onExpand} style={rowStyles.expandBtn}>
+                    <Text style={rowStyles.expandIcon}>{isExpanded ? "▾" : "▸"}</Text>
+                </TouchableOpacity>
+            )}
+        </TouchableOpacity>
+    );
+}
+
+export default function DragDropCustomRowScreen() {
+    const [data, setData] = useState<TreeNode[]>(initialData);
+    const treeViewRef = useRef<TreeViewRef | null>(null);
+    const [lastDrop, setLastDrop] = useState("");
+
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        setData(event.newTreeData);
+        const action = event.position === "inside" ? "into" : event.position;
+        setLastDrop(`Moved ${action} "${event.targetNodeId}"`);
+    }, []);
+
+    return (
+        <SafeAreaView style={screenStyles.mainView}>
+            <Text style={localStyles.header}>
+                {lastDrop || "Drag to reorganize team members"}
+            </Text>
+
+            <View style={screenStyles.selectionButtonRow}>
+                <Button title="Expand All" onPress={() => treeViewRef.current?.expandAll()} />
+                <Button title="Collapse All" onPress={() => treeViewRef.current?.collapseAll()} />
+            </View>
+            <View style={[screenStyles.selectionButtonRow, screenStyles.selectionButtonBottom]}>
+                <Button title="Reset Teams" onPress={() => { setData(initialData); setLastDrop(""); }} />
+            </View>
+
+            <View style={screenStyles.treeViewParent}>
+                <TreeView
+                    ref={treeViewRef}
+                    data={data}
+                    onCheck={() => {}}
+                    onExpand={() => {}}
+                    dragEnabled={true}
+                    onDragEnd={handleDragEnd}
+                    preExpandedIds={["team", "frontend", "backend", "devops", "design", "pm"]}
+                    CustomNodeRowComponent={TeamNodeRow}
+                    dragDropCustomizations={{
+                        draggedNodeOpacity: 0.15,
+                        dragOverlayStyleProps: {
+                            backgroundColor: "rgba(255, 255, 255, 0.98)",
+                            shadowColor: "#000",
+                            shadowOpacity: 0.2,
+                            shadowRadius: 12,
+                            elevation: 20,
+                            style: {
+                                borderRadius: 10,
+                                borderWidth: 1,
+                                borderColor: "rgba(0,0,0,0.06)",
+                            },
+                        },
+                        dropIndicatorStyleProps: {
+                            lineColor: "#4ECDC4",
+                            lineThickness: 2,
+                            circleSize: 8,
+                            highlightColor: "rgba(78, 205, 196, 0.1)",
+                            highlightBorderColor: "rgba(78, 205, 196, 0.4)",
+                        },
+                    }}
+                />
+            </View>
+        </SafeAreaView>
+    );
+}
+
+const localStyles = StyleSheet.create({
+    header: {
+        padding: 12,
+        fontSize: 13,
+        color: "#666",
+        textAlign: "center",
+        borderBottomWidth: 0.5,
+        borderColor: "lightgrey",
+    },
+});
+
+const rowStyles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingVertical: 8,
+        paddingRight: 12,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderColor: "#f0f0f0",
+    },
+    rowChecked: {
+        backgroundColor: "rgba(78, 205, 196, 0.06)",
+    },
+    avatar: {
+        width: 32,
+        height: 32,
+        borderRadius: 16,
+        alignItems: "center",
+        justifyContent: "center",
+        marginRight: 10,
+    },
+    avatarText: {
+        color: "#fff",
+        fontSize: 12,
+        fontWeight: "700",
+    },
+    folderIcon: {
+        width: 32,
+        height: 32,
+        borderRadius: 8,
+        alignItems: "center",
+        justifyContent: "center",
+        marginRight: 10,
+        backgroundColor: "#f5f5f5",
+    },
+    folderIconChecked: {
+        backgroundColor: "rgba(78, 205, 196, 0.15)",
+    },
+    folderEmoji: {
+        fontSize: 16,
+    },
+    textContainer: {
+        flex: 1,
+    },
+    name: {
+        fontSize: 15,
+        color: "#1a1a1a",
+        fontWeight: "500",
+    },
+    nameChecked: {
+        color: "#2d9a93",
+    },
+    subtitle: {
+        fontSize: 11,
+        color: "#999",
+        marginTop: 1,
+    },
+    checkbox: {
+        width: 20,
+        height: 20,
+        borderRadius: 4,
+        borderWidth: 1.5,
+        borderColor: "#ccc",
+        alignItems: "center",
+        justifyContent: "center",
+        marginLeft: 8,
+    },
+    checkboxChecked: {
+        backgroundColor: "#4ECDC4",
+        borderColor: "#4ECDC4",
+    },
+    checkboxIndeterminate: {
+        backgroundColor: "transparent",
+        borderColor: "#4ECDC4",
+    },
+    checkmark: {
+        color: "#fff",
+        fontSize: 13,
+        fontWeight: "700",
+    },
+    dash: {
+        color: "#4ECDC4",
+        fontSize: 16,
+        fontWeight: "700",
+        marginTop: -2,
+    },
+    expandBtn: {
+        paddingLeft: 8,
+        paddingVertical: 4,
+    },
+    expandIcon: {
+        fontSize: 16,
+        color: "#999",
+    },
+});

--- a/example/src/screens/DragDropScreen.tsx
+++ b/example/src/screens/DragDropScreen.tsx
@@ -1,0 +1,169 @@
+import { useRef, useState, useCallback } from "react";
+import {
+    SafeAreaView,
+    View,
+    Text,
+    StyleSheet,
+    Button,
+    Switch,
+} from "react-native";
+
+import {
+    TreeView,
+    type TreeViewRef,
+    type TreeNode,
+    type DragEndEvent,
+} from "react-native-tree-multi-select";
+
+import { styles as screenStyles } from "./screens.styles";
+
+const initialData: TreeNode[] = [
+    {
+        id: "1",
+        name: "Fruits",
+        children: [
+            { id: "1.1", name: "Apple" },
+            { id: "1.2", name: "Banana" },
+            {
+                id: "1.3",
+                name: "Citrus",
+                children: [
+                    { id: "1.3.1", name: "Orange" },
+                    { id: "1.3.2", name: "Lemon" },
+                    { id: "1.3.3", name: "Grapefruit" },
+                ],
+            },
+            { id: "1.4", name: "Cherry" },
+            { id: "1.5", name: "Mango" },
+        ],
+    },
+    {
+        id: "2",
+        name: "Vegetables",
+        children: [
+            { id: "2.1", name: "Carrot" },
+            { id: "2.2", name: "Broccoli" },
+            {
+                id: "2.3",
+                name: "Leafy Greens",
+                children: [
+                    { id: "2.3.1", name: "Spinach" },
+                    { id: "2.3.2", name: "Kale" },
+                    { id: "2.3.3", name: "Lettuce" },
+                ],
+            },
+            { id: "2.4", name: "Pepper" },
+            { id: "2.5", name: "Tomato" },
+        ],
+    },
+    {
+        id: "3",
+        name: "Grains",
+        children: [
+            { id: "3.1", name: "Rice" },
+            { id: "3.2", name: "Wheat" },
+            { id: "3.3", name: "Oats" },
+        ],
+    },
+    {
+        id: "4",
+        name: "Dairy",
+        children: [
+            { id: "4.1", name: "Milk" },
+            { id: "4.2", name: "Cheese" },
+            { id: "4.3", name: "Yogurt" },
+        ],
+    },
+    { id: "5", name: "Snacks" },
+    { id: "6", name: "Beverages" },
+];
+
+export default function DragDropScreen() {
+    const [data, setData] = useState<TreeNode[]>(initialData);
+    const treeViewRef = useRef<TreeViewRef | null>(null);
+    const [lastDrop, setLastDrop] = useState<string>("");
+    const [dragEnabled, setDragEnabled] = useState(true);
+
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        setData(event.newTreeData);
+        setLastDrop(
+            `Moved "${event.draggedNodeId}" ${event.position} "${event.targetNodeId}"`
+        );
+    }, []);
+
+    const handleSelectionChange = useCallback(
+        (_checkedIds: string[], _indeterminateIds: string[]) => {},
+        []
+    );
+
+    const handleExpanded = useCallback((_expandedIds: string[]) => {}, []);
+
+    const expandAllPress = () => treeViewRef.current?.expandAll?.();
+    const collapseAllPress = () => treeViewRef.current?.collapseAll?.();
+    const resetPress = () => {
+        setData(initialData);
+        setLastDrop("");
+    };
+
+    return (
+        <SafeAreaView style={screenStyles.mainView}>
+            {lastDrop ? (
+                <Text style={localStyles.dropInfo}>{lastDrop}</Text>
+            ) : (
+                <Text style={localStyles.dropInfo}>
+                    Long-press a node to start dragging
+                </Text>
+            )}
+
+            <View style={screenStyles.selectionButtonRow}>
+                <Button title="Expand All" onPress={expandAllPress} />
+                <Button title="Collapse All" onPress={collapseAllPress} />
+            </View>
+
+            <View
+                style={[
+                    screenStyles.selectionButtonRow,
+                    screenStyles.selectionButtonBottom,
+                ]}
+            >
+                <Button title="Reset Tree" onPress={resetPress} />
+                <View style={localStyles.toggleRow}>
+                    <Text style={localStyles.toggleLabel}>Drag</Text>
+                    <Switch value={dragEnabled} onValueChange={setDragEnabled} />
+                </View>
+            </View>
+
+            <View style={screenStyles.treeViewParent}>
+                <TreeView
+                    ref={treeViewRef}
+                    data={data}
+                    onCheck={handleSelectionChange}
+                    onExpand={handleExpanded}
+                    dragEnabled={dragEnabled}
+                    onDragEnd={handleDragEnd}
+                    preExpandedIds={["1", "2"]}
+                />
+            </View>
+        </SafeAreaView>
+    );
+}
+
+const localStyles = StyleSheet.create({
+    dropInfo: {
+        padding: 10,
+        fontSize: 13,
+        color: "#666",
+        textAlign: "center",
+        borderBottomWidth: 0.5,
+        borderColor: "lightgrey",
+    },
+    toggleRow: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    toggleLabel: {
+        fontSize: 14,
+        marginRight: 6,
+        color: "#333",
+    },
+});

--- a/example/src/screens/DragDropStyledScreen.tsx
+++ b/example/src/screens/DragDropStyledScreen.tsx
@@ -1,0 +1,138 @@
+import { useRef, useState, useCallback } from "react";
+import {
+    SafeAreaView,
+    View,
+    Text,
+    StyleSheet,
+    Button,
+} from "react-native";
+
+import {
+    TreeView,
+    type TreeViewRef,
+    type TreeNode,
+    type DragEndEvent,
+} from "react-native-tree-multi-select";
+
+import { styles as screenStyles } from "./screens.styles";
+
+const initialData: TreeNode[] = [
+    {
+        id: "1",
+        name: "Design System",
+        children: [
+            {
+                id: "1.1",
+                name: "Colors",
+                children: [
+                    { id: "1.1.1", name: "Primary" },
+                    { id: "1.1.2", name: "Secondary" },
+                    { id: "1.1.3", name: "Neutral" },
+                ],
+            },
+            {
+                id: "1.2",
+                name: "Typography",
+                children: [
+                    { id: "1.2.1", name: "Headings" },
+                    { id: "1.2.2", name: "Body Text" },
+                ],
+            },
+            { id: "1.3", name: "Spacing" },
+        ],
+    },
+    {
+        id: "2",
+        name: "Components",
+        children: [
+            { id: "2.1", name: "Button" },
+            { id: "2.2", name: "Card" },
+            { id: "2.3", name: "Modal" },
+            { id: "2.4", name: "Tooltip" },
+        ],
+    },
+    {
+        id: "3",
+        name: "Patterns",
+        children: [
+            { id: "3.1", name: "Forms" },
+            { id: "3.2", name: "Navigation" },
+            { id: "3.3", name: "Data Display" },
+        ],
+    },
+    { id: "4", name: "Utilities" },
+];
+
+export default function DragDropStyledScreen() {
+    const [data, setData] = useState<TreeNode[]>(initialData);
+    const treeViewRef = useRef<TreeViewRef | null>(null);
+    const [lastDrop, setLastDrop] = useState("");
+
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        setData(event.newTreeData);
+        setLastDrop(
+            `"${event.draggedNodeId}" → ${event.position} "${event.targetNodeId}"`
+        );
+    }, []);
+
+    return (
+        <SafeAreaView style={screenStyles.mainView}>
+            <Text style={localStyles.dropInfo}>
+                {lastDrop || "Styled drop indicator & overlay"}
+            </Text>
+
+            <View style={screenStyles.selectionButtonRow}>
+                <Button title="Expand All" onPress={() => treeViewRef.current?.expandAll()} />
+                <Button title="Collapse All" onPress={() => treeViewRef.current?.collapseAll()} />
+            </View>
+            <View style={[screenStyles.selectionButtonRow, screenStyles.selectionButtonBottom]}>
+                <Button title="Reset" onPress={() => { setData(initialData); setLastDrop(""); }} />
+            </View>
+
+            <View style={screenStyles.treeViewParent}>
+                <TreeView
+                    ref={treeViewRef}
+                    data={data}
+                    onCheck={() => {}}
+                    onExpand={() => {}}
+                    dragEnabled={true}
+                    onDragEnd={handleDragEnd}
+                    preExpandedIds={["1", "2", "3"]}
+                    dragDropCustomizations={{
+                        draggedNodeOpacity: 0.15,
+                        dragOverlayStyleProps: {
+                            backgroundColor: "rgba(230, 240, 255, 0.97)",
+                            shadowColor: "#3366FF",
+                            shadowOpacity: 0.35,
+                            shadowRadius: 8,
+                            elevation: 15,
+                            style: {
+                                borderLeftWidth: 3,
+                                borderLeftColor: "#3366FF",
+                                borderRadius: 6,
+                            },
+                        },
+                        dropIndicatorStyleProps: {
+                            lineColor: "#FF6B35",
+                            lineThickness: 3,
+                            circleSize: 12,
+                            highlightColor: "rgba(255, 107, 53, 0.12)",
+                            highlightBorderColor: "rgba(255, 107, 53, 0.5)",
+                        },
+                    }}
+                />
+            </View>
+        </SafeAreaView>
+    );
+}
+
+const localStyles = StyleSheet.create({
+    dropInfo: {
+        padding: 10,
+        fontSize: 13,
+        color: "#666",
+        textAlign: "center",
+        borderBottomWidth: 0.5,
+        borderColor: "lightgrey",
+    },
+});

--- a/release.config.js
+++ b/release.config.js
@@ -3,7 +3,7 @@ module.exports = {
     "main",
     {
       name: "beta",
-      prerelease: true // Marks this as a prerelease channel
+      prerelease: true
     }
   ],
   plugins: [
@@ -21,15 +21,88 @@ module.exports = {
         },
       },
     ],
-    "@semantic-release/release-notes-generator", // Generates release notes
-    "@semantic-release/changelog", // Generates the changelog
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        preset: "angular",
+        writerOpts: {
+          footerPartial: [
+            "{{#if noteGroups}}",
+            "{{#each noteGroups}}",
+            "",
+            "### {{title}}",
+            "",
+            "{{#each notes}}",
+            "* {{#if commit.scope}}**{{commit.scope}}:** {{/if}}{{text}}",
+            "{{/each}}",
+            "{{/each}}",
+            "",
+            "{{/if}}",
+            "{{#if contributors.length}}",
+            "",
+            "### Contributors",
+            "",
+            "{{#each contributors}}",
+            "* {{this.displayName}}",
+            "{{/each}}",
+            "{{/if}}",
+          ].join("\n"),
+          finalizeContext: (context, writerOpts, filteredCommits, keyCommit, commits) => {
+            const contributors = new Map();
+            const allCommits = commits || filteredCommits || [];
+
+            for (const commit of allCommits) {
+              if (commit.authorName) {
+                contributors.set(commit.authorName, {
+                  name: commit.authorName,
+                  email: commit.authorEmail || "",
+                });
+              }
+
+              // Extract co-authors from body and footer trailers
+              const fullText = [commit.body, commit.footer]
+                .filter(Boolean)
+                .join("\n");
+              const coAuthorRegex =
+                /Co-Authored-By:\s*(.+?)\s*<(.+?)>/gi;
+              let match;
+              while ((match = coAuthorRegex.exec(fullText)) !== null) {
+                const name = match[1].trim();
+                contributors.set(name, {
+                  name,
+                  email: match[2].trim(),
+                });
+              }
+            }
+
+            context.contributors = Array.from(contributors.values()).map(
+              (c) => {
+                // Link GitHub users by email pattern, show others as bold text
+                const ghMatch = c.email.match(
+                  /^(\d+\+)?(.+)@users\.noreply\.github\.com$/
+                );
+                return {
+                  ...c,
+                  displayName: ghMatch
+                    ? `@${ghMatch[2]}`
+                    : `**${c.name}**`,
+                };
+              }
+            );
+
+            return context;
+          },
+        },
+      },
+    ],
+    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
         npmPublish: true,
       }
     ],
-    "@semantic-release/github", // Handles GitHub releases
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {

--- a/src/TreeView.tsx
+++ b/src/TreeView.tsx
@@ -26,6 +26,8 @@ import type {
 	ScrollToNodeHandlerRef,
 	ScrollToNodeParams
 } from "./handlers/ScrollToNodeHandler";
+import type { DragEndEvent } from "./types/dragDrop.types";
+import { fastIsEqual } from "fast-is-equal";
 
 function _innerTreeView<ID>(
 	props: TreeViewProps<ID>,
@@ -54,6 +56,15 @@ function _innerTreeView<ID>(
 		ExpandCollapseTouchableComponent,
 
 		CustomNodeRowComponent,
+
+		dragEnabled,
+		onDragEnd,
+		longPressDuration,
+		autoScrollThreshold,
+		autoScrollSpeed,
+		dragOverlayOffset,
+		autoExpandDelay,
+		dragDropCustomizations,
 	} = props;
 
 	const storeId = useId();
@@ -123,8 +134,22 @@ function _innerTreeView<ID>(
 
 	const scrollToNodeHandlerRef = React.useRef<ScrollToNodeHandlerRef<ID>>(null);
 	const prevSearchText = usePreviousState(searchText);
+	const internalDataRef = React.useRef<TreeNode<ID>[] | null>(null);
+
+	// Wrap onDragEnd to set internalDataRef before calling consumer's callback
+	const wrappedOnDragEnd = React.useCallback((event: DragEndEvent<ID>) => {
+		internalDataRef.current = event.newTreeData;
+		onDragEnd?.(event);
+	}, [onDragEnd]);
 
 	useDeepCompareEffect(() => {
+		// If data matches what was set internally from a drag-drop, skip reinitialize
+		if (internalDataRef.current !== null && fastIsEqual(data, internalDataRef.current)) {
+			internalDataRef.current = null;
+			return;
+		}
+		internalDataRef.current = null;
+
 		cleanUpTreeViewStore();
 
 		updateInitialTreeViewData(data);
@@ -227,6 +252,15 @@ function _innerTreeView<ID>(
 			ExpandCollapseTouchableComponent={ExpandCollapseTouchableComponent}
 
 			CustomNodeRowComponent={CustomNodeRowComponent}
+
+			dragEnabled={dragEnabled}
+			onDragEnd={wrappedOnDragEnd}
+			longPressDuration={longPressDuration}
+			autoScrollThreshold={autoScrollThreshold}
+			autoScrollSpeed={autoScrollSpeed}
+			dragOverlayOffset={dragOverlayOffset}
+			autoExpandDelay={autoExpandDelay}
+			dragDropCustomizations={dragDropCustomizations}
 		/>
 	);
 }

--- a/src/__tests__/dragDrop.store.test.ts
+++ b/src/__tests__/dragDrop.store.test.ts
@@ -1,0 +1,385 @@
+jest.mock("zustand");
+
+import { act } from "react-test-renderer";
+import { getTreeViewStore } from "../store/treeView.store";
+import { initializeNodeMaps, toggleCheckboxes, recalculateCheckedStates } from "../helpers";
+import { moveTreeNode } from "../helpers/moveTreeNode.helper";
+import type { TreeNode } from "../types/treeView.types";
+
+const STORE_ID = "drag-drop-test-store";
+
+/**
+ * Test tree:
+ *  1
+ *  ├── 1.1
+ *  │   ├── 1.1.1
+ *  │   └── 1.1.2
+ *  └── 1.2
+ *  2
+ *  ├── 2.1
+ *  └── 2.2
+ *  3 (leaf)
+ */
+function makeTree(): TreeNode<string>[] {
+    return [
+        {
+            id: "1", name: "node1", children: [
+                {
+                    id: "1.1", name: "node1.1", children: [
+                        { id: "1.1.1", name: "node1.1.1" },
+                        { id: "1.1.2", name: "node1.1.2" },
+                    ]
+                },
+                { id: "1.2", name: "node1.2" },
+            ]
+        },
+        {
+            id: "2", name: "node2", children: [
+                { id: "2.1", name: "node2.1" },
+                { id: "2.2", name: "node2.2" },
+            ]
+        },
+        { id: "3", name: "node3" },
+    ];
+}
+
+describe("Drag-and-drop store state", () => {
+    const store = getTreeViewStore<string>(STORE_ID);
+
+    beforeEach(() => {
+        store.getState().cleanUpTreeViewStore();
+    });
+
+    // =====================
+    // draggedNodeId
+    // =====================
+    describe("draggedNodeId", () => {
+        it("starts as null", () => {
+            expect(store.getState().draggedNodeId).toBeNull();
+        });
+
+        it("updates to a node ID", () => {
+            act(() => {
+                store.getState().updateDraggedNodeId("1.1");
+            });
+            expect(store.getState().draggedNodeId).toBe("1.1");
+        });
+
+        it("resets back to null", () => {
+            act(() => {
+                store.getState().updateDraggedNodeId("1.1");
+            });
+            act(() => {
+                store.getState().updateDraggedNodeId(null);
+            });
+            expect(store.getState().draggedNodeId).toBeNull();
+        });
+    });
+
+    // =====================
+    // invalidDragTargetIds
+    // =====================
+    describe("invalidDragTargetIds", () => {
+        it("starts as empty set", () => {
+            expect(store.getState().invalidDragTargetIds.size).toBe(0);
+        });
+
+        it("updates with a set of IDs", () => {
+            const ids = new Set(["1", "1.1", "1.1.1", "1.1.2", "1.2"]);
+            act(() => {
+                store.getState().updateInvalidDragTargetIds(ids);
+            });
+            expect(store.getState().invalidDragTargetIds).toEqual(ids);
+        });
+
+        it("resets back to empty set", () => {
+            act(() => {
+                store.getState().updateInvalidDragTargetIds(new Set(["1"]));
+            });
+            act(() => {
+                store.getState().updateInvalidDragTargetIds(new Set());
+            });
+            expect(store.getState().invalidDragTargetIds.size).toBe(0);
+        });
+    });
+
+    // =====================
+    // dropTarget state
+    // =====================
+    describe("dropTarget state", () => {
+        it("starts with null dropTargetNodeId and dropPosition", () => {
+            expect(store.getState().dropTargetNodeId).toBeNull();
+            expect(store.getState().dropPosition).toBeNull();
+        });
+
+        it("updates drop target with node ID and position", () => {
+            act(() => {
+                store.getState().updateDropTarget("2.1", "above");
+            });
+            expect(store.getState().dropTargetNodeId).toBe("2.1");
+            expect(store.getState().dropPosition).toBe("above");
+        });
+
+        it("updates drop target to different positions", () => {
+            act(() => {
+                store.getState().updateDropTarget("1", "inside");
+            });
+            expect(store.getState().dropTargetNodeId).toBe("1");
+            expect(store.getState().dropPosition).toBe("inside");
+
+            act(() => {
+                store.getState().updateDropTarget("1", "below");
+            });
+            expect(store.getState().dropTargetNodeId).toBe("1");
+            expect(store.getState().dropPosition).toBe("below");
+        });
+
+        it("clears drop target when set to null", () => {
+            act(() => {
+                store.getState().updateDropTarget("1.1", "above");
+            });
+            expect(store.getState().dropTargetNodeId).toBe("1.1");
+
+            act(() => {
+                store.getState().updateDropTarget(null, null);
+            });
+            expect(store.getState().dropTargetNodeId).toBeNull();
+            expect(store.getState().dropPosition).toBeNull();
+        });
+
+        it("changes drop target to a different node", () => {
+            act(() => {
+                store.getState().updateDropTarget("1", "above");
+            });
+            act(() => {
+                store.getState().updateDropTarget("2", "below");
+            });
+            expect(store.getState().dropTargetNodeId).toBe("2");
+            expect(store.getState().dropPosition).toBe("below");
+        });
+    });
+
+    // =====================
+    // cleanUpTreeViewStore includes drag state
+    // =====================
+    describe("cleanUpTreeViewStore", () => {
+        it("resets all drag state on cleanup", () => {
+            act(() => {
+                store.getState().updateDraggedNodeId("1");
+                store.getState().updateInvalidDragTargetIds(new Set(["1", "1.1"]));
+                store.getState().updateDropTarget("2", "inside");
+            });
+
+            expect(store.getState().draggedNodeId).toBe("1");
+            expect(store.getState().invalidDragTargetIds.size).toBe(2);
+            expect(store.getState().dropTargetNodeId).toBe("2");
+            expect(store.getState().dropPosition).toBe("inside");
+
+            act(() => {
+                store.getState().cleanUpTreeViewStore();
+            });
+
+            expect(store.getState().draggedNodeId).toBeNull();
+            expect(store.getState().invalidDragTargetIds.size).toBe(0);
+            expect(store.getState().dropTargetNodeId).toBeNull();
+            expect(store.getState().dropPosition).toBeNull();
+        });
+    });
+});
+
+describe("Drag-drop integration with checked/expanded state", () => {
+    const store = getTreeViewStore<string>(STORE_ID);
+
+    beforeEach(() => {
+        store.getState().cleanUpTreeViewStore();
+        const tree = makeTree();
+        act(() => {
+            store.getState().updateInitialTreeViewData(tree);
+            initializeNodeMaps(STORE_ID, tree);
+        });
+    });
+
+    it("preserves checked state after moveTreeNode + store update", () => {
+        // Check nodes 1.1.1 and 2.1
+        act(() => {
+            toggleCheckboxes(STORE_ID, ["1.1.1", "2.1"], true);
+        });
+
+        const { checked: checkedBefore } = store.getState();
+        expect(checkedBefore.has("1.1.1")).toBe(true);
+        expect(checkedBefore.has("2.1")).toBe(true);
+
+        // Simulate a drag: move "3" above "1"
+        const currentData = store.getState().initialTreeViewData;
+        const newData = moveTreeNode(currentData, "3", "1", "above");
+
+        act(() => {
+            store.getState().updateInitialTreeViewData(newData);
+            initializeNodeMaps(STORE_ID, newData);
+        });
+
+        // Checked state should still be intact
+        const { checked: checkedAfter } = store.getState();
+        expect(checkedAfter.has("1.1.1")).toBe(true);
+        expect(checkedAfter.has("2.1")).toBe(true);
+    });
+
+    it("preserves expanded state after moveTreeNode + store update", () => {
+        // Expand nodes 1 and 2
+        act(() => {
+            store.getState().updateExpanded(new Set(["1", "2"]));
+        });
+
+        const { expanded: expandedBefore } = store.getState();
+        expect(expandedBefore.has("1")).toBe(true);
+        expect(expandedBefore.has("2")).toBe(true);
+
+        // Simulate a drag: move "1.2" inside "2"
+        const currentData = store.getState().initialTreeViewData;
+        const newData = moveTreeNode(currentData, "1.2", "2", "inside");
+
+        act(() => {
+            store.getState().updateInitialTreeViewData(newData);
+            initializeNodeMaps(STORE_ID, newData);
+        });
+
+        // Expanded state should still be intact
+        const { expanded: expandedAfter } = store.getState();
+        expect(expandedAfter.has("1")).toBe(true);
+        expect(expandedAfter.has("2")).toBe(true);
+    });
+
+    it("updated tree structure is correct after store update", () => {
+        const currentData = store.getState().initialTreeViewData;
+        const newData = moveTreeNode(currentData, "2.1", "1.1", "inside");
+
+        act(() => {
+            store.getState().updateInitialTreeViewData(newData);
+            initializeNodeMaps(STORE_ID, newData);
+        });
+
+        const { nodeMap, childToParentMap } = store.getState();
+
+        // 2.1 should now be a child of 1.1
+        expect(childToParentMap.get("2.1")).toBe("1.1");
+
+        // 1.1 should have 3 children: 2.1 (prepended), 1.1.1, 1.1.2
+        const node1_1 = nodeMap.get("1.1");
+        expect(node1_1?.children?.length).toBe(3);
+        expect(node1_1?.children?.[0]?.id).toBe("2.1");
+    });
+
+    it("invalid drag targets include self and all descendants", () => {
+        // Simulate dragging node "1" — descendants are 1.1, 1.1.1, 1.1.2, 1.2
+        const { nodeMap } = store.getState();
+
+        // Build descendant set like useDragDrop does
+        const descendants = new Set<string>();
+        const stack: string[] = ["1"];
+        while (stack.length > 0) {
+            const currentId = stack.pop()!;
+            const node = nodeMap.get(currentId);
+            if (node?.children) {
+                for (const child of node.children) {
+                    descendants.add(child.id);
+                    stack.push(child.id);
+                }
+            }
+        }
+        descendants.add("1"); // Add self
+
+        expect(descendants).toEqual(new Set(["1", "1.1", "1.1.1", "1.1.2", "1.2"]));
+
+        // Setting these as invalid targets
+        act(() => {
+            store.getState().updateInvalidDragTargetIds(descendants);
+        });
+
+        const { invalidDragTargetIds } = store.getState();
+        expect(invalidDragTargetIds.has("1")).toBe(true);
+        expect(invalidDragTargetIds.has("1.1")).toBe(true);
+        expect(invalidDragTargetIds.has("1.1.1")).toBe(true);
+        expect(invalidDragTargetIds.has("1.1.2")).toBe(true);
+        expect(invalidDragTargetIds.has("1.2")).toBe(true);
+
+        // Valid targets
+        expect(invalidDragTargetIds.has("2")).toBe(false);
+        expect(invalidDragTargetIds.has("2.1")).toBe(false);
+        expect(invalidDragTargetIds.has("3")).toBe(false);
+    });
+
+    it("full drag lifecycle with recalculation: checked parent becomes indeterminate after unchecked node moved in", () => {
+        // Check all of 2's children → 2 becomes checked
+        act(() => {
+            toggleCheckboxes(STORE_ID, ["2.1", "2.2"], true);
+        });
+
+        expect(store.getState().checked.has("2")).toBe(true);
+
+        // 1. Start drag on node "3" (unchecked leaf)
+        act(() => {
+            store.getState().updateDraggedNodeId("3");
+            store.getState().updateInvalidDragTargetIds(new Set(["3"]));
+            store.getState().updateDropTarget("2", "inside");
+        });
+
+        // 2. Move "3" inside "2" and recalculate
+        const currentData = store.getState().initialTreeViewData;
+        const newData = moveTreeNode(currentData, "3", "2", "inside");
+        act(() => {
+            store.getState().updateInitialTreeViewData(newData);
+            initializeNodeMaps(STORE_ID, newData);
+            recalculateCheckedStates<string>(STORE_ID);
+        });
+
+        // 2 now has [3✗, 2.1✓, 2.2✓] → indeterminate
+        const { checked, indeterminate } = store.getState();
+        expect(checked.has("2")).toBe(false);
+        expect(indeterminate.has("2")).toBe(true);
+        expect(checked.has("2.1")).toBe(true);
+        expect(checked.has("2.2")).toBe(true);
+        expect(checked.has("3")).toBe(false);
+
+        // 3. Clear drag state
+        act(() => {
+            store.getState().updateDraggedNodeId(null);
+            store.getState().updateInvalidDragTargetIds(new Set());
+            store.getState().updateDropTarget(null, null);
+        });
+
+        expect(store.getState().draggedNodeId).toBeNull();
+        expect(store.getState().invalidDragTargetIds.size).toBe(0);
+        expect(store.getState().dropTargetNodeId).toBeNull();
+    });
+
+    it("full drag lifecycle: set drag state → move → clear drag state", () => {
+        // 1. Start drag on node "3"
+        act(() => {
+            store.getState().updateDraggedNodeId("3");
+            store.getState().updateInvalidDragTargetIds(new Set(["3"]));
+        });
+        expect(store.getState().draggedNodeId).toBe("3");
+
+        // 2. Perform the move: "3" above "1"
+        const currentData = store.getState().initialTreeViewData;
+        const newData = moveTreeNode(currentData, "3", "1", "above");
+        act(() => {
+            store.getState().updateInitialTreeViewData(newData);
+            initializeNodeMaps(STORE_ID, newData);
+        });
+
+        // Verify the move
+        const { initialTreeViewData } = store.getState();
+        expect(initialTreeViewData[0]!.id).toBe("3");
+        expect(initialTreeViewData[1]!.id).toBe("1");
+        expect(initialTreeViewData[2]!.id).toBe("2");
+
+        // 3. Clear drag state
+        act(() => {
+            store.getState().updateDraggedNodeId(null);
+            store.getState().updateInvalidDragTargetIds(new Set());
+        });
+        expect(store.getState().draggedNodeId).toBeNull();
+        expect(store.getState().invalidDragTargetIds.size).toBe(0);
+    });
+});

--- a/src/__tests__/moveTreeNode.helper.test.ts
+++ b/src/__tests__/moveTreeNode.helper.test.ts
@@ -1,0 +1,333 @@
+import { moveTreeNode } from "../helpers/moveTreeNode.helper";
+import type { TreeNode } from "../types/treeView.types";
+
+/**
+ * Helper tree for most tests:
+ *
+ *  A
+ *  ├── A1
+ *  │   ├── A1a
+ *  │   └── A1b
+ *  └── A2
+ *  B
+ *  ├── B1
+ *  └── B2
+ *  C (leaf)
+ */
+function makeTree(): TreeNode<string>[] {
+    return [
+        {
+            id: "A", name: "A", children: [
+                {
+                    id: "A1", name: "A1", children: [
+                        { id: "A1a", name: "A1a" },
+                        { id: "A1b", name: "A1b" },
+                    ]
+                },
+                { id: "A2", name: "A2" },
+            ]
+        },
+        {
+            id: "B", name: "B", children: [
+                { id: "B1", name: "B1" },
+                { id: "B2", name: "B2" },
+            ]
+        },
+        { id: "C", name: "C" },
+    ];
+}
+
+/** Collect all node IDs in DFS order */
+function collectIds<ID>(nodes: TreeNode<ID>[]): ID[] {
+    const ids: ID[] = [];
+    for (const n of nodes) {
+        ids.push(n.id);
+        if (n.children) ids.push(...collectIds(n.children));
+    }
+    return ids;
+}
+
+/** Find a node by ID in tree */
+function findNode<ID>(nodes: TreeNode<ID>[], id: ID): TreeNode<ID> | null {
+    for (const n of nodes) {
+        if (n.id === id) return n;
+        if (n.children) {
+            const found = findNode(n.children, id);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+
+describe("moveTreeNode", () => {
+    // =====================
+    // POSITION: "above"
+    // =====================
+    describe("position: \"above\"", () => {
+        it("moves a leaf node above a root sibling", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "C", "A", "above");
+
+            expect(result[0]!.id).toBe("C");
+            expect(result[1]!.id).toBe("A");
+            expect(result[2]!.id).toBe("B");
+            expect(result.length).toBe(3);
+        });
+
+        it("moves a deep node above another deep node", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A1b", "B1", "above");
+
+            const B = findNode(result, "B")!;
+            expect(B.children![0]!.id).toBe("A1b");
+            expect(B.children![1]!.id).toBe("B1");
+            expect(B.children![2]!.id).toBe("B2");
+
+            // A1b should be gone from A1
+            const A1 = findNode(result, "A1")!;
+            expect(A1.children!.length).toBe(1);
+            expect(A1.children![0]!.id).toBe("A1a");
+        });
+
+        it("moves a parent node (with children) above a root node", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A1", "B", "above");
+
+            expect(result[0]!.id).toBe("A");
+            expect(result[1]!.id).toBe("A1");
+            expect(result[1]!.children!.length).toBe(2); // A1a, A1b preserved
+            expect(result[2]!.id).toBe("B");
+
+            // A should no longer have A1 as a child
+            const A = result[0]!;
+            expect(A.children!.length).toBe(1);
+            expect(A.children![0]!.id).toBe("A2");
+        });
+    });
+
+    // =====================
+    // POSITION: "below"
+    // =====================
+    describe("position: \"below\"", () => {
+        it("moves a leaf node below a root node", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "C", "A", "below");
+
+            expect(result[0]!.id).toBe("A");
+            expect(result[1]!.id).toBe("C");
+            expect(result[2]!.id).toBe("B");
+        });
+
+        it("moves a node below the last root node", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A2", "C", "below");
+
+            expect(result.length).toBe(4); // A, B, C, A2 at root
+            expect(result[3]!.id).toBe("A2");
+        });
+
+        it("moves a deep child below another deep child", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "B2", "A1a", "below");
+
+            const A1 = findNode(result, "A1")!;
+            expect(A1.children![0]!.id).toBe("A1a");
+            expect(A1.children![1]!.id).toBe("B2");
+            expect(A1.children![2]!.id).toBe("A1b");
+
+            // B should have lost B2
+            const B = findNode(result, "B")!;
+            expect(B.children!.length).toBe(1);
+            expect(B.children![0]!.id).toBe("B1");
+        });
+    });
+
+    // =====================
+    // POSITION: "inside"
+    // =====================
+    describe("position: \"inside\"", () => {
+        it("moves a node inside a leaf node (creates children)", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "B1", "C", "inside");
+
+            const C = findNode(result, "C")!;
+            expect(C.children).toBeDefined();
+            expect(C.children!.length).toBe(1);
+            expect(C.children![0]!.id).toBe("B1");
+        });
+
+        it("moves a node inside a parent (prepends as first child)", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "C", "B", "inside");
+
+            const B = findNode(result, "B")!;
+            expect(B.children![0]!.id).toBe("C");
+            expect(B.children![1]!.id).toBe("B1");
+            expect(B.children![2]!.id).toBe("B2");
+
+            // C removed from root
+            expect(result.length).toBe(2);
+        });
+
+        it("moves a subtree inside another node, preserving the subtree's children", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A1", "C", "inside");
+
+            const C = findNode(result, "C")!;
+            expect(C.children!.length).toBe(1);
+            expect(C.children![0]!.id).toBe("A1");
+            expect(C.children![0]!.children!.length).toBe(2);
+            expect(C.children![0]!.children![0]!.id).toBe("A1a");
+            expect(C.children![0]!.children![1]!.id).toBe("A1b");
+        });
+    });
+
+    // =====================
+    // EDGE CASES
+    // =====================
+    describe("edge cases", () => {
+        it("returns original data when dragging onto self", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A", "A", "above");
+            expect(result).toBe(tree); // Same reference = no-op
+        });
+
+        it("does not mutate the original tree", () => {
+            const tree = makeTree();
+            const originalIds = collectIds(tree);
+
+            moveTreeNode(tree, "C", "A", "above");
+
+            const afterIds = collectIds(tree);
+            expect(afterIds).toEqual(originalIds);
+        });
+
+        it("preserves all node IDs after move (no data loss)", () => {
+            const tree = makeTree();
+            const originalIds = new Set(collectIds(tree));
+
+            const result = moveTreeNode(tree, "A1", "C", "inside");
+            const resultIds = new Set(collectIds(result));
+
+            expect(resultIds).toEqual(originalIds);
+        });
+
+        it("returns original data when dragged node ID doesn't exist", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "NONEXISTENT", "A", "above");
+            expect(result).toBe(tree);
+        });
+
+        it("returns original data when target node ID doesn't exist", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A", "NONEXISTENT", "above");
+            expect(result).toBe(tree);
+        });
+
+        it("cleans up empty children array when last child is removed", () => {
+            // Tree with single child: X -> X1
+            const tree: TreeNode<string>[] = [
+                { id: "X", name: "X", children: [{ id: "X1", name: "X1" }] },
+                { id: "Y", name: "Y" },
+            ];
+
+            const result = moveTreeNode(tree, "X1", "Y", "below");
+
+            const X = findNode(result, "X")!;
+            expect(X.children).toBeUndefined();
+        });
+
+        it("handles moving first child to a different position", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A1a", "A1b", "below");
+
+            const A1 = findNode(result, "A1")!;
+            expect(A1.children![0]!.id).toBe("A1b");
+            expect(A1.children![1]!.id).toBe("A1a");
+        });
+
+        it("handles single-node tree", () => {
+            const tree: TreeNode<string>[] = [{ id: "only", name: "only" }];
+            const result = moveTreeNode(tree, "only", "only", "inside");
+            expect(result).toBe(tree); // Self-drop is no-op
+        });
+
+        it("handles moving root node to inside another root node", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A", "B", "inside");
+
+            expect(result.length).toBe(2); // B and C at root
+            const B = findNode(result, "B")!;
+            expect(B.children![0]!.id).toBe("A");
+            expect(B.children![0]!.children!.length).toBe(2); // A1, A2 preserved
+        });
+    });
+
+    // =====================
+    // NUMERIC IDs
+    // =====================
+    describe("numeric IDs", () => {
+        it("works with number-type IDs", () => {
+            const tree: TreeNode<number>[] = [
+                {
+                    id: 1, name: "One", children: [
+                        { id: 11, name: "OneOne" },
+                        { id: 12, name: "OneTwo" },
+                    ]
+                },
+                { id: 2, name: "Two" },
+                { id: 3, name: "Three" },
+            ];
+
+            const result = moveTreeNode(tree, 3, 1, "inside");
+
+            const one = findNode(result, 1)!;
+            expect(one.children![0]!.id).toBe(3);
+            expect(one.children![1]!.id).toBe(11);
+            expect(result.length).toBe(2);
+        });
+    });
+
+    // =====================
+    // COMPLEX MOVES
+    // =====================
+    describe("complex multi-level moves", () => {
+        it("moves a deeply nested node to root level", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "A1a", "C", "below");
+
+            expect(result.length).toBe(4);
+            expect(result[3]!.id).toBe("A1a");
+
+            // A1 should still have A1b
+            const A1 = findNode(result, "A1")!;
+            expect(A1.children!.length).toBe(1);
+            expect(A1.children![0]!.id).toBe("A1b");
+        });
+
+        it("moves a root node to become a deeply nested child", () => {
+            const tree = makeTree();
+            const result = moveTreeNode(tree, "C", "A1a", "inside");
+
+            expect(result.length).toBe(2); // A, B at root
+            const A1a = findNode(result, "A1a")!;
+            expect(A1a.children!.length).toBe(1);
+            expect(A1a.children![0]!.id).toBe("C");
+        });
+
+        it("preserves all IDs through a chain of moves", () => {
+            let tree = makeTree();
+            const originalIds = new Set(collectIds(tree));
+
+            // Move C inside A1
+            tree = moveTreeNode(tree, "C", "A1", "inside");
+            // Move B1 above A
+            tree = moveTreeNode(tree, "B1", "A", "above");
+            // Move A2 below B
+            tree = moveTreeNode(tree, "A2", "B", "below");
+
+            const finalIds = new Set(collectIds(tree));
+            expect(finalIds).toEqual(originalIds);
+        });
+    });
+});

--- a/src/__tests__/recalculateCheckedStates.test.ts
+++ b/src/__tests__/recalculateCheckedStates.test.ts
@@ -1,0 +1,574 @@
+jest.mock("zustand");
+
+import { act } from "react-test-renderer";
+import { getTreeViewStore } from "../store/treeView.store";
+import { initializeNodeMaps, toggleCheckboxes, recalculateCheckedStates } from "../helpers";
+import { moveTreeNode } from "../helpers/moveTreeNode.helper";
+import type { TreeNode } from "../types/treeView.types";
+
+const STORE_ID = "recalculate-test-store";
+
+/**
+ * Test tree:
+ *  1
+ *  ├── 1.1
+ *  │   ├── 1.1.1
+ *  │   └── 1.1.2
+ *  └── 1.2
+ *  2
+ *  ├── 2.1
+ *  └── 2.2
+ *  3 (leaf)
+ */
+function makeTree(): TreeNode<string>[] {
+    return [
+        {
+            id: "1", name: "node1", children: [
+                {
+                    id: "1.1", name: "node1.1", children: [
+                        { id: "1.1.1", name: "node1.1.1" },
+                        { id: "1.1.2", name: "node1.1.2" },
+                    ]
+                },
+                { id: "1.2", name: "node1.2" },
+            ]
+        },
+        {
+            id: "2", name: "node2", children: [
+                { id: "2.1", name: "node2.1" },
+                { id: "2.2", name: "node2.2" },
+            ]
+        },
+        { id: "3", name: "node3" },
+    ];
+}
+
+/**
+ * Simulates a drag-drop move: moveTreeNode + updateInitialTreeViewData +
+ * initializeNodeMaps + recalculateCheckedStates, matching the real
+ * handleDragEnd flow.
+ */
+function simulateDragDrop(
+    draggedNodeId: string,
+    targetNodeId: string,
+    position: "above" | "below" | "inside"
+) {
+    const store = getTreeViewStore<string>(STORE_ID);
+    const currentData = store.getState().initialTreeViewData;
+    const newData = moveTreeNode(currentData, draggedNodeId, targetNodeId, position);
+
+    act(() => {
+        store.getState().updateInitialTreeViewData(newData);
+        initializeNodeMaps(STORE_ID, newData);
+        recalculateCheckedStates<string>(STORE_ID);
+    });
+
+    return newData;
+}
+
+describe("recalculateCheckedStates", () => {
+    const store = getTreeViewStore<string>(STORE_ID);
+
+    beforeEach(() => {
+        store.getState().cleanUpTreeViewStore();
+        const tree = makeTree();
+        act(() => {
+            store.getState().updateInitialTreeViewData(tree);
+            initializeNodeMaps(STORE_ID, tree);
+        });
+    });
+
+    // =====================
+    // BASIC PARENT RECALCULATION
+    // =====================
+    describe("parent state recalculation after move", () => {
+        it("makes fully-checked parent indeterminate when unchecked node is moved inside", () => {
+            // Check all children of 2 → parent 2 becomes checked
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["2.1", "2.2"], true);
+            });
+
+            const { checked: before } = store.getState();
+            expect(before.has("2")).toBe(true);
+            expect(before.has("2.1")).toBe(true);
+            expect(before.has("2.2")).toBe(true);
+
+            // Move unchecked leaf "3" inside node "2"
+            simulateDragDrop("3", "2", "inside");
+
+            // 2 now has children [3✗, 2.1✓, 2.2✓] → should be indeterminate
+            const { checked, indeterminate } = store.getState();
+            expect(checked.has("2")).toBe(false);
+            expect(indeterminate.has("2")).toBe(true);
+            expect(checked.has("2.1")).toBe(true);
+            expect(checked.has("2.2")).toBe(true);
+            expect(checked.has("3")).toBe(false);
+        });
+
+        it("makes indeterminate parent unchecked when only checked child is moved out", () => {
+            // Check 1.1.1 → 1.1 becomes indeterminate, 1 becomes indeterminate
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.1"], true);
+            });
+
+            expect(store.getState().indeterminate.has("1.1")).toBe(true);
+            expect(store.getState().indeterminate.has("1")).toBe(true);
+
+            // Move the checked leaf 1.1.1 out → below node 3
+            simulateDragDrop("1.1.1", "3", "below");
+
+            // 1.1 now has only [1.1.2✗] → unchecked
+            // 1 now has [1.1✗, 1.2✗] → unchecked
+            const { checked, indeterminate } = store.getState();
+            expect(checked.has("1.1")).toBe(false);
+            expect(indeterminate.has("1.1")).toBe(false);
+            expect(checked.has("1")).toBe(false);
+            expect(indeterminate.has("1")).toBe(false);
+
+            // The moved leaf retains its checked state
+            expect(checked.has("1.1.1")).toBe(true);
+        });
+
+        it("makes parent checked when all children become checked after move", () => {
+            // Check 2.1 only → 2 becomes indeterminate
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["2.1"], true);
+            });
+
+            expect(store.getState().indeterminate.has("2")).toBe(true);
+
+            // Move unchecked 2.2 out → below 3
+            simulateDragDrop("2.2", "3", "below");
+
+            // 2 now has only [2.1✓] → fully checked
+            const { checked, indeterminate } = store.getState();
+            expect(checked.has("2")).toBe(true);
+            expect(indeterminate.has("2")).toBe(false);
+        });
+    });
+
+    // =====================
+    // CROSS-BRANCH MOVES
+    // =====================
+    describe("cross-branch moves update both old and new parent chains", () => {
+        it("updates both source and target parent chains", () => {
+            // Check all of node 1's subtree → 1 is fully checked
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1"], true);
+            });
+
+            expect(store.getState().checked.has("1")).toBe(true);
+            expect(store.getState().checked.has("1.1")).toBe(true);
+            expect(store.getState().checked.has("1.2")).toBe(true);
+
+            // Move checked leaf 1.2 inside unchecked node 2
+            simulateDragDrop("1.2", "2", "inside");
+
+            const { checked, indeterminate } = store.getState();
+
+            // Source: 1 still has [1.1✓] → 1 stays checked
+            expect(checked.has("1")).toBe(true);
+            expect(checked.has("1.1")).toBe(true);
+
+            // Target: 2 now has [1.2✓, 2.1✗, 2.2✗] → indeterminate
+            expect(checked.has("2")).toBe(false);
+            expect(indeterminate.has("2")).toBe(true);
+            expect(checked.has("1.2")).toBe(true);
+        });
+
+        it("moves checked subtree between branches and recalculates grandparents", () => {
+            // Check 1.1 (and its children via propagation) → 1.1 checked, 1 indeterminate
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1"], true);
+            });
+
+            expect(store.getState().checked.has("1.1")).toBe(true);
+            expect(store.getState().checked.has("1.1.1")).toBe(true);
+            expect(store.getState().checked.has("1.1.2")).toBe(true);
+            expect(store.getState().indeterminate.has("1")).toBe(true);
+
+            // Move entire subtree 1.1 inside node 2
+            simulateDragDrop("1.1", "2", "inside");
+
+            const { checked, indeterminate } = store.getState();
+
+            // Source: 1 now has only [1.2✗] → unchecked
+            expect(checked.has("1")).toBe(false);
+            expect(indeterminate.has("1")).toBe(false);
+
+            // Target: 2 now has [1.1✓, 2.1✗, 2.2✗] → indeterminate
+            expect(checked.has("2")).toBe(false);
+            expect(indeterminate.has("2")).toBe(true);
+
+            // Moved subtree retains internal checked state
+            expect(checked.has("1.1")).toBe(true);
+            expect(checked.has("1.1.1")).toBe(true);
+            expect(checked.has("1.1.2")).toBe(true);
+        });
+    });
+
+    // =====================
+    // LEAF INDETERMINATE CLEANUP
+    // =====================
+    describe("leaf node indeterminate cleanup", () => {
+        it("clears indeterminate from a node that loses all its children", () => {
+            // Make 2 have only 1 child: remove 2.2 first
+            simulateDragDrop("2.2", "3", "below");
+
+            // Now node 2 has one child [2.1]. Check 2.1 → 2 becomes checked.
+            // Then uncheck 2.1 → 2 becomes unchecked.
+            // But let's create indeterminate some other way...
+
+            // Reset and use a tree where node has 1 indeterminate child
+            store.getState().cleanUpTreeViewStore();
+            const tree: TreeNode<string>[] = [
+                {
+                    id: "P", name: "Parent", children: [
+                        {
+                            id: "C", name: "Child", children: [
+                                { id: "C1", name: "C1" },
+                                { id: "C2", name: "C2" },
+                            ]
+                        },
+                    ]
+                },
+                { id: "X", name: "X" },
+            ];
+            act(() => {
+                store.getState().updateInitialTreeViewData(tree);
+                initializeNodeMaps(STORE_ID, tree);
+            });
+
+            // Check C1 only → C becomes indeterminate, P becomes indeterminate
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["C1"], true);
+            });
+
+            expect(store.getState().indeterminate.has("C")).toBe(true);
+            expect(store.getState().indeterminate.has("P")).toBe(true);
+
+            // Move the only child C out of P → P becomes a leaf
+            const currentData = store.getState().initialTreeViewData;
+            const newData = moveTreeNode(currentData, "C", "X", "below");
+            act(() => {
+                store.getState().updateInitialTreeViewData(newData);
+                initializeNodeMaps(STORE_ID, newData);
+                recalculateCheckedStates<string>(STORE_ID);
+            });
+
+            // P is now a leaf — must NOT be indeterminate
+            const { checked, indeterminate } = store.getState();
+            expect(indeterminate.has("P")).toBe(false);
+            expect(checked.has("P")).toBe(false);
+
+            // C retains its indeterminate state (it still has children C1✓, C2✗)
+            expect(indeterminate.has("C")).toBe(true);
+            expect(checked.has("C1")).toBe(true);
+            expect(checked.has("C2")).toBe(false);
+        });
+    });
+
+    // =====================
+    // SELECTION PROPAGATION MODES
+    // =====================
+    describe("respects selectionPropagation settings", () => {
+        it("does not recalculate when toParents is false", () => {
+            // Set toParents = false
+            act(() => {
+                store.getState().setSelectionPropagation({
+                    toChildren: true,
+                    toParents: false,
+                });
+            });
+
+            // Manually set 2 as checked (simulating direct user action)
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["2"], true);
+            });
+
+            // 2 should be checked (along with children via toChildren)
+            expect(store.getState().checked.has("2")).toBe(true);
+            expect(store.getState().checked.has("2.1")).toBe(true);
+            expect(store.getState().checked.has("2.2")).toBe(true);
+
+            // Move unchecked "3" inside "2"
+            simulateDragDrop("3", "2", "inside");
+
+            // With toParents=false, recalculate is a no-op → 2 stays checked
+            const { checked } = store.getState();
+            expect(checked.has("2")).toBe(true);
+            expect(checked.has("3")).toBe(false);
+        });
+
+        it("recalculates correctly with default selectionPropagation (both true)", () => {
+            // Default is toChildren: true, toParents: true
+            // Check all of 2's children
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["2.1", "2.2"], true);
+            });
+
+            expect(store.getState().checked.has("2")).toBe(true);
+
+            // Move unchecked "1.2" inside "2"
+            simulateDragDrop("1.2", "2", "inside");
+
+            // 2 has [1.2✗, 2.1✓, 2.2✓] → indeterminate
+            const { checked, indeterminate } = store.getState();
+            expect(checked.has("2")).toBe(false);
+            expect(indeterminate.has("2")).toBe(true);
+        });
+    });
+
+    // =====================
+    // COMPLEX MULTI-LEVEL SCENARIOS
+    // =====================
+    describe("complex multi-level recalculation", () => {
+        it("recalculates entire ancestor chain when deeply nested node is moved", () => {
+            // Check 1.1.1 → 1.1 indeterminate, 1 indeterminate
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.1"], true);
+            });
+
+            expect(store.getState().indeterminate.has("1.1")).toBe(true);
+            expect(store.getState().indeterminate.has("1")).toBe(true);
+
+            // Also check 1.1.2 → 1.1 becomes checked, 1 still indeterminate
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.2"], true);
+            });
+
+            expect(store.getState().checked.has("1.1")).toBe(true);
+            expect(store.getState().indeterminate.has("1")).toBe(true);
+
+            // Move 1.1.1 (checked) inside node 2
+            simulateDragDrop("1.1.1", "2", "inside");
+
+            const { checked, indeterminate } = store.getState();
+
+            // 1.1 now has [1.1.2✓] → checked
+            expect(checked.has("1.1")).toBe(true);
+
+            // 1 has [1.1✓, 1.2✗] → indeterminate (unchanged)
+            expect(indeterminate.has("1")).toBe(true);
+
+            // 2 has [1.1.1✓, 2.1✗, 2.2✗] → indeterminate
+            expect(indeterminate.has("2")).toBe(true);
+        });
+
+        it("handles chain of moves maintaining consistency", () => {
+            // Check 1.1.1 and 2.1
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.1", "2.1"], true);
+            });
+
+            // Move 1: 1.1.1 inside 2
+            simulateDragDrop("1.1.1", "2", "inside");
+
+            // 1.1 was indeterminate (had 1.1.1✓, 1.1.2✗), now has [1.1.2✗] → unchecked
+            expect(store.getState().checked.has("1.1")).toBe(false);
+            expect(store.getState().indeterminate.has("1.1")).toBe(false);
+
+            // 1 has [1.1✗, 1.2✗] → unchecked
+            expect(store.getState().checked.has("1")).toBe(false);
+            expect(store.getState().indeterminate.has("1")).toBe(false);
+
+            // 2 has [1.1.1✓, 2.1✓, 2.2✗] → indeterminate
+            expect(store.getState().indeterminate.has("2")).toBe(true);
+
+            // Move 2: 2.2 (unchecked) above 3
+            simulateDragDrop("2.2", "3", "above");
+
+            // 2 now has [1.1.1✓, 2.1✓] → all checked → 2 becomes checked
+            const { checked, indeterminate } = store.getState();
+            expect(checked.has("2")).toBe(true);
+            expect(indeterminate.has("2")).toBe(false);
+        });
+
+        it("handles moving a checked node into a fully unchecked subtree", () => {
+            // Check node 3
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["3"], true);
+            });
+
+            // Move checked 3 inside unchecked 1.1
+            simulateDragDrop("3", "1.1", "inside");
+
+            const { checked, indeterminate } = store.getState();
+
+            // 1.1 has [3✓, 1.1.1✗, 1.1.2✗] → indeterminate
+            expect(indeterminate.has("1.1")).toBe(true);
+            expect(checked.has("1.1")).toBe(false);
+
+            // 1 has [1.1(indeterminate), 1.2✗] → indeterminate
+            expect(indeterminate.has("1")).toBe(true);
+            expect(checked.has("1")).toBe(false);
+        });
+
+        it("handles moving all checked children out of parent → parent becomes unchecked", () => {
+            // Check all of 2's children → 2 is checked
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["2.1", "2.2"], true);
+            });
+
+            expect(store.getState().checked.has("2")).toBe(true);
+
+            // Move 2.1 out
+            simulateDragDrop("2.1", "3", "below");
+
+            // 2 has [2.2✓] → still checked
+            expect(store.getState().checked.has("2")).toBe(true);
+
+            // Move 2.2 out
+            simulateDragDrop("2.2", "3", "below");
+
+            // 2 has no children → children is undefined → it's a leaf
+            const { checked, indeterminate, nodeMap } = store.getState();
+            expect(nodeMap.get("2")?.children).toBeUndefined();
+            expect(checked.has("2")).toBe(true); // Keeps its checked state as a leaf
+            expect(indeterminate.has("2")).toBe(false); // Must NOT be indeterminate as a leaf
+        });
+    });
+
+    // =====================
+    // EDGE CASES
+    // =====================
+    describe("edge cases", () => {
+        it("does not crash on empty tree", () => {
+            store.getState().cleanUpTreeViewStore();
+            act(() => {
+                store.getState().updateInitialTreeViewData([]);
+                initializeNodeMaps(STORE_ID, []);
+            });
+
+            // Should not throw
+            act(() => {
+                recalculateCheckedStates<string>(STORE_ID);
+            });
+
+            const { checked, indeterminate } = store.getState();
+            expect(checked.size).toBe(0);
+            expect(indeterminate.size).toBe(0);
+        });
+
+        it("handles tree with single node correctly", () => {
+            store.getState().cleanUpTreeViewStore();
+            const singleTree: TreeNode<string>[] = [{ id: "only", name: "only" }];
+            act(() => {
+                store.getState().updateInitialTreeViewData(singleTree);
+                initializeNodeMaps(STORE_ID, singleTree);
+                toggleCheckboxes(STORE_ID, ["only"], true);
+            });
+
+            act(() => {
+                recalculateCheckedStates<string>(STORE_ID);
+            });
+
+            // Single checked leaf should remain checked
+            expect(store.getState().checked.has("only")).toBe(true);
+            expect(store.getState().indeterminate.has("only")).toBe(false);
+        });
+
+        it("does not affect leaf node checked states", () => {
+            // Check some leaf nodes
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.1", "2.2", "3"], true);
+            });
+
+            // Recalculate without moving anything
+            act(() => {
+                recalculateCheckedStates<string>(STORE_ID);
+            });
+
+            // Leaf checked states are unchanged
+            const { checked } = store.getState();
+            expect(checked.has("1.1.1")).toBe(true);
+            expect(checked.has("2.2")).toBe(true);
+            expect(checked.has("3")).toBe(true);
+
+            // Unchecked leaves remain unchecked
+            expect(checked.has("1.1.2")).toBe(false);
+            expect(checked.has("1.2")).toBe(false);
+            expect(checked.has("2.1")).toBe(false);
+        });
+
+        it("is idempotent — calling twice produces same result", () => {
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.1", "2.1"], true);
+            });
+
+            simulateDragDrop("1.1.1", "2", "inside");
+
+            const { checked: checked1, indeterminate: indeterminate1 } = store.getState();
+            const checked1Arr = Array.from(checked1).sort();
+            const indeterminate1Arr = Array.from(indeterminate1).sort();
+
+            // Call recalculate again
+            act(() => {
+                recalculateCheckedStates<string>(STORE_ID);
+            });
+
+            const { checked: checked2, indeterminate: indeterminate2 } = store.getState();
+            expect(Array.from(checked2).sort()).toEqual(checked1Arr);
+            expect(Array.from(indeterminate2).sort()).toEqual(indeterminate1Arr);
+        });
+
+        it("handles moving node to same parent (reorder) without state change", () => {
+            // Check 1.1.1
+            act(() => {
+                toggleCheckboxes(STORE_ID, ["1.1.1"], true);
+            });
+
+            const { checked: before, indeterminate: indBefore } = store.getState();
+            const beforeChecked = Array.from(before).sort();
+            const beforeIndet = Array.from(indBefore).sort();
+
+            // Move 1.1.1 below 1.1.2 (reorder within same parent)
+            simulateDragDrop("1.1.1", "1.1.2", "below");
+
+            const { checked: after, indeterminate: indAfter } = store.getState();
+            expect(Array.from(after).sort()).toEqual(beforeChecked);
+            expect(Array.from(indAfter).sort()).toEqual(beforeIndet);
+        });
+    });
+
+    // =====================
+    // NUMERIC IDs
+    // =====================
+    describe("numeric IDs", () => {
+        it("works with number-type IDs", () => {
+            const numStore = getTreeViewStore<number>("recalc-num-store");
+            numStore.getState().cleanUpTreeViewStore();
+
+            const numTree: TreeNode<number>[] = [
+                {
+                    id: 1, name: "One", children: [
+                        { id: 11, name: "OneOne" },
+                        { id: 12, name: "OneTwo" },
+                    ]
+                },
+                { id: 2, name: "Two" },
+            ];
+
+            act(() => {
+                numStore.getState().updateInitialTreeViewData(numTree);
+                initializeNodeMaps("recalc-num-store", numTree);
+                toggleCheckboxes("recalc-num-store", [11, 12], true);
+            });
+
+            // 1 should be fully checked
+            expect(numStore.getState().checked.has(1)).toBe(true);
+
+            // Move unchecked 2 inside 1
+            const newData = moveTreeNode(numTree, 2, 1, "inside");
+            act(() => {
+                numStore.getState().updateInitialTreeViewData(newData);
+                initializeNodeMaps("recalc-num-store", newData);
+                recalculateCheckedStates<number>("recalc-num-store");
+            });
+
+            // 1 has [2✗, 11✓, 12✓] → indeterminate
+            expect(numStore.getState().checked.has(1)).toBe(false);
+            expect(numStore.getState().indeterminate.has(1)).toBe(true);
+        });
+    });
+});

--- a/src/components/DragOverlay.tsx
+++ b/src/components/DragOverlay.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { Animated, StyleSheet, View } from "react-native";
+
+import type {
+    __FlattenedTreeNode__,
+    CheckBoxViewProps,
+    DragDropCustomizations,
+    TreeItemCustomizations,
+} from "../types/treeView.types";
+import { CheckboxView } from "./CheckboxView";
+import { CustomExpandCollapseIcon } from "./CustomExpandCollapseIcon";
+import { defaultIndentationMultiplier } from "../constants/treeView.constants";
+
+interface DragOverlayProps<ID> extends TreeItemCustomizations<ID> {
+    overlayY: Animated.Value;
+    node: __FlattenedTreeNode__<ID>;
+    level: number;
+    dragDropCustomizations?: DragDropCustomizations<ID>;
+}
+
+function _DragOverlay<ID>(props: DragOverlayProps<ID>) {
+    const {
+        overlayY,
+        node,
+        level,
+        indentationMultiplier = defaultIndentationMultiplier,
+        CheckboxComponent = CheckboxView as React.ComponentType<CheckBoxViewProps>,
+        ExpandCollapseIconComponent = CustomExpandCollapseIcon,
+        CustomNodeRowComponent,
+        checkBoxViewStyleProps,
+        dragDropCustomizations,
+    } = props;
+
+    const overlayStyleProps = dragDropCustomizations?.dragOverlayStyleProps;
+    const CustomOverlay = dragDropCustomizations?.CustomDragOverlayComponent;
+
+    return (
+        <Animated.View
+            pointerEvents="none"
+            style={[
+                styles.overlay,
+                overlayStyleProps && {
+                    ...(overlayStyleProps.backgroundColor != null && { backgroundColor: overlayStyleProps.backgroundColor }),
+                    ...(overlayStyleProps.shadowColor != null && { shadowColor: overlayStyleProps.shadowColor }),
+                    ...(overlayStyleProps.shadowOpacity != null && { shadowOpacity: overlayStyleProps.shadowOpacity }),
+                    ...(overlayStyleProps.shadowRadius != null && { shadowRadius: overlayStyleProps.shadowRadius }),
+                    ...(overlayStyleProps.elevation != null && { elevation: overlayStyleProps.elevation }),
+                },
+                overlayStyleProps?.style,
+                { transform: [{ translateY: overlayY }] },
+            ]}
+        >
+            {CustomOverlay ? (
+                <CustomOverlay node={node} level={level} />
+            ) : CustomNodeRowComponent ? (
+                <CustomNodeRowComponent
+                    node={node}
+                    level={level}
+                    checkedValue={false}
+                    isExpanded={false}
+                    onCheck={() => {}}
+                    onExpand={() => {}}
+                />
+            ) : (
+                <View
+                    style={[
+                        styles.nodeRow,
+                        { paddingStart: level * indentationMultiplier },
+                    ]}
+                >
+                    <CheckboxComponent
+                        text={node.name}
+                        onValueChange={() => {}}
+                        value={false}
+                        {...checkBoxViewStyleProps}
+                    />
+                    {node.children?.length ? (
+                        <View style={styles.expandArrow}>
+                            <ExpandCollapseIconComponent isExpanded={false} />
+                        </View>
+                    ) : null}
+                </View>
+            )}
+        </Animated.View>
+    );
+}
+
+export const DragOverlay = React.memo(_DragOverlay) as typeof _DragOverlay;
+
+const styles = StyleSheet.create({
+    overlay: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        elevation: 10,
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        backgroundColor: "rgba(255, 255, 255, 0.95)",
+    },
+    nodeRow: {
+        flex: 1,
+        flexDirection: "row",
+        alignItems: "center",
+        minWidth: "100%",
+    },
+    expandArrow: {
+        flex: 1,
+    },
+});

--- a/src/components/DropIndicator.tsx
+++ b/src/components/DropIndicator.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { Animated, View, StyleSheet } from "react-native";
+import type { DropPosition } from "../types/dragDrop.types";
+
+interface DropIndicatorProps {
+    position: DropPosition;
+    overlayY: Animated.Value;
+    itemHeight: number;
+    targetLevel: number;
+    indentationMultiplier: number;
+}
+
+export const DropIndicator = React.memo(function DropIndicator(
+    props: DropIndicatorProps
+) {
+    const {
+        position,
+        overlayY,
+        itemHeight,
+        targetLevel,
+        indentationMultiplier,
+    } = props;
+
+    const indent = targetLevel * indentationMultiplier;
+
+    if (position === "inside") {
+        return (
+            <Animated.View
+                pointerEvents="none"
+                style={[
+                    styles.highlightIndicator,
+                    {
+                        transform: [{ translateY: overlayY }],
+                        height: itemHeight,
+                        left: indent,
+                    },
+                ]}
+            />
+        );
+    }
+
+    // For "above", the line is at the overlay's top edge (offset 0)
+    // For "below", the line is at the overlay's bottom edge (offset +itemHeight)
+    const lineOffset = position === "above" ? 0 : itemHeight;
+
+    return (
+        <Animated.View
+            pointerEvents="none"
+            style={[
+                styles.lineContainer,
+                {
+                    transform: [{ translateY: Animated.add(overlayY, lineOffset - 1) }],
+                    left: indent,
+                },
+            ]}
+        >
+            <View style={styles.lineCircle} />
+            <View style={styles.line} />
+        </Animated.View>
+    );
+});
+
+const styles = StyleSheet.create({
+    highlightIndicator: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        backgroundColor: "rgba(0, 200, 0, 0.2)",
+        borderWidth: 2,
+        borderColor: "rgba(0, 200, 0, 0.6)",
+        borderRadius: 4,
+        zIndex: 9998,
+    },
+    lineContainer: {
+        position: "absolute",
+        right: 0,
+        flexDirection: "row",
+        alignItems: "center",
+        height: 3,
+        zIndex: 9998,
+    },
+    lineCircle: {
+        width: 10,
+        height: 10,
+        borderRadius: 5,
+        backgroundColor: "#00CC00",
+        marginLeft: -5,
+        marginTop: -4,
+    },
+    line: {
+        flex: 1,
+        height: 3,
+        backgroundColor: "#00CC00",
+    },
+});

--- a/src/components/NodeList.tsx
+++ b/src/components/NodeList.tsx
@@ -448,7 +448,7 @@ function NodeDropIndicator({ position, styleProps }: {
             style={[
                 styles.dropLineContainer,
                 { height: lineThickness },
-                position === "above" ? { top: 0 } : { bottom: 0 },
+                position === "above" ? styles.dropLineTop : styles.dropLineBottom,
             ]}
         >
             <View style={[
@@ -510,6 +510,12 @@ const styles = StyleSheet.create({
         alignItems: "center",
         height: 3,
         zIndex: 10,
+    },
+    dropLineTop: {
+        top: 0,
+    },
+    dropLineBottom: {
+        bottom: 0,
     },
     dropLineCircle: {
         width: 10,

--- a/src/components/NodeList.tsx
+++ b/src/components/NodeList.tsx
@@ -2,16 +2,19 @@ import React from "react";
 import {
     View,
     StyleSheet,
-
     TouchableOpacity,
+    type NativeSyntheticEvent,
+    type NativeScrollEvent,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 
 import type {
     CheckboxValueType,
     __FlattenedTreeNode__,
+    DropIndicatorStyleProps,
     NodeListProps,
     NodeProps,
+    TreeNode,
 } from "../types/treeView.types";
 
 import { useTreeViewStore } from "../store/treeView.store";
@@ -24,10 +27,13 @@ import {
 } from "../helpers";
 import { CheckboxView } from "./CheckboxView";
 import { CustomExpandCollapseIcon } from "./CustomExpandCollapseIcon";
+import { DragOverlay } from "./DragOverlay";
+import type { DropPosition } from "../types/dragDrop.types";
 import { defaultIndentationMultiplier } from "../constants/treeView.constants";
 import { useShallow } from "zustand/react/shallow";
 import { typedMemo } from "../utils/typedMemo";
 import { ScrollToNodeHandler } from "../handlers/ScrollToNodeHandler";
+import { useDragDrop } from "../hooks/useDragDrop";
 
 const NodeList = typedMemo(_NodeList);
 export default NodeList;
@@ -46,7 +52,16 @@ function _NodeList<ID>(props: NodeListProps<ID>) {
         CheckboxComponent,
         ExpandCollapseIconComponent,
         ExpandCollapseTouchableComponent,
-        CustomNodeRowComponent
+        CustomNodeRowComponent,
+
+        dragEnabled,
+        onDragEnd,
+        longPressDuration = 400,
+        autoScrollThreshold = 60,
+        autoScrollSpeed = 1.0,
+        dragOverlayOffset = -4,
+        autoExpandDelay = 800,
+        dragDropCustomizations,
     } = props;
 
     const {
@@ -66,6 +81,15 @@ function _NodeList<ID>(props: NodeListProps<ID>) {
     ));
 
     const flashListRef = React.useRef<FlashList<__FlattenedTreeNode__<ID>> | null>(null);
+    const containerRef = React.useRef<View>(null);
+    const internalDataRef = React.useRef<TreeNode<ID>[] | null>(null);
+    const measuredItemHeightRef = React.useRef(0);
+
+    const handleItemLayout = React.useCallback((height: number) => {
+        if (measuredItemHeightRef.current === 0 && height > 0) {
+            measuredItemHeightRef.current = height;
+        }
+    }, []);
 
     const [initialScrollIndex, setInitialScrollIndex] = React.useState<number>(-1);
 
@@ -90,8 +114,46 @@ function _NodeList<ID>(props: NodeListProps<ID>) {
         updateInnerMostChildrenIds(updatedInnerMostChildrenIds);
     }, [filteredTree, updateInnerMostChildrenIds]);
 
+    // --- Drag and drop ---
+    const {
+        panResponder,
+        overlayY,
+        isDragging,
+        draggedNode,
+        handleNodeTouchStart,
+        cancelLongPressTimer,
+        scrollOffsetRef,
+    } = useDragDrop<ID>({
+        storeId,
+        flattenedNodes: flattenedFilteredNodes,
+        flashListRef,
+        containerRef,
+        dragEnabled: dragEnabled ?? false,
+        onDragEnd,
+        longPressDuration,
+        autoScrollThreshold,
+        autoScrollSpeed,
+        internalDataRef,
+        measuredItemHeightRef,
+        dragOverlayOffset,
+        autoExpandDelay,
+    });
+
+    // Combined onScroll handler
+    const handleScroll = React.useCallback((
+        event: NativeSyntheticEvent<NativeScrollEvent>
+    ) => {
+        scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
+        // Cancel long press timer if user is scrolling
+        cancelLongPressTimer();
+        // Forward to user's onScroll
+        treeFlashListProps?.onScroll?.(event as any);
+    }, [scrollOffsetRef, cancelLongPressTimer, treeFlashListProps]);
+
+    const effectiveIndentationMultiplier = indentationMultiplier ?? defaultIndentationMultiplier;
+
     const nodeRenderer = React.useCallback((
-        { item }: { item: __FlattenedTreeNode__<ID>; }
+        { item, index }: { item: __FlattenedTreeNode__<ID>; index: number; }
     ) => {
         return (
             <Node<ID>
@@ -107,6 +169,14 @@ function _NodeList<ID>(props: NodeListProps<ID>) {
                 ExpandCollapseIconComponent={ExpandCollapseIconComponent}
                 ExpandCollapseTouchableComponent={ExpandCollapseTouchableComponent}
                 CustomNodeRowComponent={CustomNodeRowComponent}
+
+                nodeIndex={index}
+                dragEnabled={dragEnabled}
+                isDragging={isDragging}
+                onNodeTouchStart={dragEnabled ? handleNodeTouchStart : undefined}
+                onNodeTouchEnd={dragEnabled ? cancelLongPressTimer : undefined}
+                onItemLayout={dragEnabled ? handleItemLayout : undefined}
+                dragDropCustomizations={dragDropCustomizations}
             />
         );
     }, [
@@ -116,8 +186,36 @@ function _NodeList<ID>(props: NodeListProps<ID>) {
         ExpandCollapseTouchableComponent,
         CustomNodeRowComponent,
         checkBoxViewStyleProps,
-        indentationMultiplier
+        indentationMultiplier,
+        dragEnabled,
+        isDragging,
+        handleNodeTouchStart,
+        dragDropCustomizations,
+        cancelLongPressTimer,
+        handleItemLayout,
     ]);
+
+    // Extract FlashList props but exclude onScroll (we provide our own combined handler)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { onScroll: _userOnScroll, ...restFlashListProps } = treeFlashListProps ?? {};
+
+    const flashListElement = (
+        <FlashList
+            ref={flashListRef}
+            estimatedItemSize={36}
+            initialScrollIndex={initialScrollIndex}
+            removeClippedSubviews={true}
+            keyboardShouldPersistTaps="handled"
+            drawDistance={50}
+            ListHeaderComponent={<HeaderFooterView />}
+            ListFooterComponent={<HeaderFooterView />}
+            {...restFlashListProps}
+            onScroll={handleScroll}
+            scrollEnabled={isDragging ? false : (restFlashListProps?.scrollEnabled ?? true)}
+            data={flattenedFilteredNodes}
+            renderItem={nodeRenderer}
+        />
+    );
 
     return (
         <>
@@ -129,19 +227,30 @@ function _NodeList<ID>(props: NodeListProps<ID>) {
                 setInitialScrollIndex={setInitialScrollIndex}
                 initialScrollNodeID={initialScrollNodeID} />
 
-            <FlashList
-                ref={flashListRef}
-                estimatedItemSize={36}
-                initialScrollIndex={initialScrollIndex}
-                removeClippedSubviews={true}
-                keyboardShouldPersistTaps="handled"
-                drawDistance={50}
-                ListHeaderComponent={<HeaderFooterView />}
-                ListFooterComponent={<HeaderFooterView />}
-                {...treeFlashListProps}
-                data={flattenedFilteredNodes}
-                renderItem={nodeRenderer}
-            />
+            {dragEnabled ? (
+                <View
+                    ref={containerRef}
+                    style={styles.dragContainer}
+                    {...panResponder.panHandlers}
+                >
+                    {flashListElement}
+                    {isDragging && draggedNode && (
+                        <DragOverlay<ID>
+                            overlayY={overlayY}
+                            node={draggedNode}
+                            level={draggedNode.level ?? 0}
+                            indentationMultiplier={effectiveIndentationMultiplier}
+                            CheckboxComponent={CheckboxComponent}
+                            ExpandCollapseIconComponent={ExpandCollapseIconComponent}
+                            CustomNodeRowComponent={CustomNodeRowComponent}
+                            checkBoxViewStyleProps={checkBoxViewStyleProps}
+                            dragDropCustomizations={dragDropCustomizations}
+                        />
+                    )}
+                </View>
+            ) : (
+                flashListElement
+            )}
         </>
     );
 };
@@ -179,19 +288,35 @@ function _Node<ID>(props: NodeProps<ID>) {
         ExpandCollapseIconComponent = CustomExpandCollapseIcon,
         CheckboxComponent = CheckboxView,
         ExpandCollapseTouchableComponent = TouchableOpacity,
-        CustomNodeRowComponent
+        CustomNodeRowComponent,
+
+        nodeIndex = 0,
+        dragEnabled,
+        isDragging: isDraggingGlobal,
+        onNodeTouchStart,
+        onNodeTouchEnd,
+        onItemLayout,
+        dragDropCustomizations,
     } = props;
 
     const {
         isExpanded,
         value,
+        isBeingDragged,
+        isDragInvalid,
+        isDropTarget,
+        nodeDropPosition,
     } = useTreeViewStore<ID>(storeId)(useShallow(
         state => ({
             isExpanded: state.expanded.has(node.id),
             value: getValue(
-                state.checked.has(node.id), // isChecked
-                state.indeterminate.has(node.id) // isIndeterminate
+                state.checked.has(node.id),
+                state.indeterminate.has(node.id)
             ),
+            isBeingDragged: state.draggedNodeId === node.id,
+            isDragInvalid: state.invalidDragTargetIds.has(node.id),
+            isDropTarget: state.dropTargetNodeId === node.id,
+            nodeDropPosition: state.dropTargetNodeId === node.id ? state.dropPosition : null,
         })
     ));
 
@@ -203,14 +328,51 @@ function _Node<ID>(props: NodeProps<ID>) {
         toggleCheckboxes(storeId, [node.id]);
     }, [storeId, node.id]);
 
+    const handleTouchStart = React.useCallback((e: any) => {
+        if (!onNodeTouchStart) return;
+        const { pageY, locationY } = e.nativeEvent;
+        onNodeTouchStart(node.id, pageY, locationY, nodeIndex);
+    }, [node.id, nodeIndex, onNodeTouchStart]);
+
+    const handleTouchEnd = React.useCallback(() => {
+        onNodeTouchEnd?.();
+    }, [onNodeTouchEnd]);
+
+    // Determine opacity for drag state
+    const dragOpacity = dragDropCustomizations?.draggedNodeOpacity ?? 0.3;
+    const nodeOpacity = (isDraggingGlobal && (isBeingDragged || isDragInvalid))
+        ? dragOpacity
+        : 1.0;
+
+    const handleLayout = React.useCallback((e: any) => {
+        onItemLayout?.(e.nativeEvent.layout.height);
+    }, [onItemLayout]);
+
+    const touchHandlers = dragEnabled ? {
+        onTouchStart: handleTouchStart,
+        onTouchEnd: handleTouchEnd,
+        onTouchCancel: handleTouchEnd,
+    } : undefined;
+
+    const CustomDropIndicator = dragDropCustomizations?.CustomDropIndicatorComponent;
+    const dropIndicator = isDropTarget && nodeDropPosition ? (
+        CustomDropIndicator
+            ? <CustomDropIndicator position={nodeDropPosition} />
+            : <NodeDropIndicator position={nodeDropPosition} styleProps={dragDropCustomizations?.dropIndicatorStyleProps} />
+    ) : null;
+
     if (!CustomNodeRowComponent) {
         return (
             <View
                 testID={`node_row_${node.id}`}
+                {...touchHandlers}
+                onLayout={onItemLayout ? handleLayout : undefined}
                 style={[
                     styles.nodeCheckboxAndArrowRow,
-                    { paddingStart: level * indentationMultiplier }
+                    { paddingStart: level * indentationMultiplier },
+                    { opacity: nodeOpacity },
                 ]}>
+                {dropIndicator}
                 <CheckboxComponent
                     text={node.name}
                     onValueChange={_onCheck}
@@ -233,16 +395,83 @@ function _Node<ID>(props: NodeProps<ID>) {
     }
     else {
         return (
-            <CustomNodeRowComponent
-                node={node}
-                level={level}
-                checkedValue={value}
-                isExpanded={isExpanded}
-                onCheck={_onCheck}
-                onExpand={_onToggleExpand} />
+            <View
+                {...touchHandlers}
+                onLayout={onItemLayout ? handleLayout : undefined}
+                style={{ opacity: nodeOpacity }}
+            >
+                {dropIndicator}
+                <CustomNodeRowComponent
+                    node={node}
+                    level={level}
+                    checkedValue={value}
+                    isExpanded={isExpanded}
+                    onCheck={_onCheck}
+                    onExpand={_onToggleExpand}
+                    isDragTarget={isDragInvalid}
+                    isDragging={isDraggingGlobal}
+                    isDraggedNode={isBeingDragged}
+                />
+            </View>
         );
     }
 };
+
+function NodeDropIndicator({ position, styleProps }: {
+    position: DropPosition;
+    styleProps?: DropIndicatorStyleProps;
+}) {
+    const lineColor = styleProps?.lineColor ?? "#0078FF";
+    const lineThickness = styleProps?.lineThickness ?? 3;
+    const circleSize = styleProps?.circleSize ?? 10;
+    const highlightColor = styleProps?.highlightColor ?? "rgba(0, 120, 255, 0.15)";
+    const highlightBorderColor = styleProps?.highlightBorderColor ?? "rgba(0, 120, 255, 0.5)";
+
+    if (position === "inside") {
+        return (
+            <View
+                pointerEvents="none"
+                style={[
+                    styles.dropHighlight,
+                    {
+                        backgroundColor: highlightColor,
+                        borderColor: highlightBorderColor,
+                    },
+                ]}
+            />
+        );
+    }
+
+    return (
+        <View
+            pointerEvents="none"
+            style={[
+                styles.dropLineContainer,
+                { height: lineThickness },
+                position === "above" ? { top: 0 } : { bottom: 0 },
+            ]}
+        >
+            <View style={[
+                styles.dropLineCircle,
+                {
+                    width: circleSize,
+                    height: circleSize,
+                    borderRadius: circleSize / 2,
+                    backgroundColor: lineColor,
+                    marginLeft: -(circleSize / 2),
+                    marginTop: -(circleSize / 2 - lineThickness / 2),
+                },
+            ]} />
+            <View style={[
+                styles.dropLine,
+                {
+                    height: lineThickness,
+                    backgroundColor: lineColor,
+                },
+            ]} />
+        </View>
+    );
+}
 
 const styles = StyleSheet.create({
     defaultHeaderFooter: {
@@ -256,6 +485,43 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         minWidth: "100%"
-    }
+    },
+    dragContainer: {
+        flex: 1,
+    },
+    // Drop indicator styles (rendered by each node)
+    dropHighlight: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        backgroundColor: "rgba(0, 120, 255, 0.15)",
+        borderWidth: 2,
+        borderColor: "rgba(0, 120, 255, 0.5)",
+        borderRadius: 4,
+        zIndex: 10,
+    },
+    dropLineContainer: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        flexDirection: "row",
+        alignItems: "center",
+        height: 3,
+        zIndex: 10,
+    },
+    dropLineCircle: {
+        width: 10,
+        height: 10,
+        borderRadius: 5,
+        backgroundColor: "#0078FF",
+        marginLeft: -5,
+        marginTop: -4,
+    },
+    dropLine: {
+        flex: 1,
+        height: 3,
+        backgroundColor: "#0078FF",
+    },
 });
-

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,3 +6,4 @@ export * from "./selectAll.helper";
 export * from "./toggleCheckbox.helper";
 export * from "./search.helper";
 export * from "./flattenTree.helper";
+export * from "./moveTreeNode.helper";

--- a/src/helpers/moveTreeNode.helper.ts
+++ b/src/helpers/moveTreeNode.helper.ts
@@ -1,0 +1,105 @@
+import type { TreeNode } from "../types/treeView.types";
+import type { DropPosition } from "../types/dragDrop.types";
+
+/**
+ * Move a node within a tree structure. Returns a new tree (no mutation).
+ *
+ * @param data - The current tree data
+ * @param draggedNodeId - The ID of the node to move
+ * @param targetNodeId - The ID of the target node
+ * @param position - Where to place relative to target: "above", "below", or "inside"
+ * @returns New tree data with the node moved, or the original data if the move is invalid
+ */
+export function moveTreeNode<ID>(
+    data: TreeNode<ID>[],
+    draggedNodeId: ID,
+    targetNodeId: ID,
+    position: DropPosition
+): TreeNode<ID>[] {
+    if (draggedNodeId === targetNodeId) return data;
+
+    // Step 1: Deep clone the tree
+    const cloned = deepCloneTree(data);
+
+    // Step 2: Remove the dragged node
+    const removedNode = removeNodeById(cloned, draggedNodeId);
+    if (!removedNode) return data;
+
+    // Step 3: Insert at the new position
+    const inserted = insertNode(cloned, removedNode, targetNodeId, position);
+    if (!inserted) return data;
+
+    return cloned;
+}
+
+function deepCloneTree<ID>(nodes: TreeNode<ID>[]): TreeNode<ID>[] {
+    return nodes.map(node => ({
+        ...node,
+        children: node.children ? deepCloneTree(node.children) : undefined,
+    }));
+}
+
+/**
+ * Remove a node by ID from the tree. Mutates the cloned tree in-place.
+ * Returns the removed node, or null if not found.
+ */
+function removeNodeById<ID>(
+    nodes: TreeNode<ID>[],
+    nodeId: ID,
+): TreeNode<ID> | null {
+    for (let i = 0; i < nodes.length; i++) {
+        if (nodes[i]!.id === nodeId) {
+            const [removed] = nodes.splice(i, 1);
+            return removed!;
+        }
+        const children = nodes[i]!.children;
+        if (children) {
+            const removed = removeNodeById(children, nodeId);
+            if (removed) {
+                // Clean up empty children arrays
+                if (children.length === 0) {
+                    nodes[i] = { ...nodes[i]!, children: undefined };
+                }
+                return removed;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Insert a node relative to a target node. Mutates the cloned tree in-place.
+ * Returns true if insertion was successful.
+ */
+function insertNode<ID>(
+    nodes: TreeNode<ID>[],
+    nodeToInsert: TreeNode<ID>,
+    targetId: ID,
+    position: DropPosition,
+): boolean {
+    for (let i = 0; i < nodes.length; i++) {
+        if (nodes[i]!.id === targetId) {
+            if (position === "above") {
+                nodes.splice(i, 0, nodeToInsert);
+            } else if (position === "below") {
+                nodes.splice(i + 1, 0, nodeToInsert);
+            } else {
+                // "inside" - add as first child
+                const target = nodes[i]!;
+                if (target.children) {
+                    target.children.unshift(nodeToInsert);
+                } else {
+                    nodes[i] = { ...target, children: [nodeToInsert] };
+                }
+            }
+            return true;
+        }
+        const children = nodes[i]!.children;
+        if (children) {
+            if (insertNode(children, nodeToInsert, targetId, position)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/src/helpers/toggleCheckbox.helper.ts
+++ b/src/helpers/toggleCheckbox.helper.ts
@@ -200,3 +200,99 @@ export function toggleCheckboxes<ID>(
     updateChecked(tempChecked);
     updateIndeterminate(tempIndeterminate);
 }
+
+/**
+ * Recalculates checked/indeterminate state for all parent nodes bottom-up.
+ * Should be called after tree structure changes (e.g., drag-drop moves) to ensure
+ * parent states correctly reflect their children's checked states.
+ */
+export function recalculateCheckedStates<ID>(storeId: string) {
+    const treeViewStore = getTreeViewStore<ID>(storeId);
+    const {
+        checked,
+        updateChecked,
+        indeterminate,
+        updateIndeterminate,
+        nodeMap,
+        childToParentMap,
+        selectionPropagation,
+    } = treeViewStore.getState();
+
+    // Only recalculate if parent propagation is enabled
+    if (!selectionPropagation.toParents) return;
+
+    const tempChecked = new Set(checked);
+    const tempIndeterminate = new Set(indeterminate);
+
+    // Collect parent nodes and clean up leaf nodes that shouldn't be indeterminate.
+    // A leaf node (no children) can never be indeterminate — this can happen when
+    // all children of a formerly-indeterminate parent are dragged away.
+    const parentNodes: ID[] = [];
+    for (const [id, node] of nodeMap) {
+        if (node.children && node.children.length > 0) {
+            parentNodes.push(id);
+        } else {
+            tempIndeterminate.delete(id);
+        }
+    }
+
+    // Sort by depth descending (deepest first) for correct bottom-up propagation
+    const nodeDepths = new Map<ID, number>();
+    function getDepth(nodeId: ID): number {
+        if (nodeDepths.has(nodeId)) return nodeDepths.get(nodeId)!;
+        let depth = 0;
+        let currentId: ID | undefined = nodeId;
+        while (currentId) {
+            const parentId = childToParentMap.get(currentId);
+            if (parentId) {
+                depth++;
+                currentId = parentId;
+            } else {
+                break;
+            }
+        }
+        nodeDepths.set(nodeId, depth);
+        return depth;
+    }
+
+    parentNodes.sort((a, b) => getDepth(b) - getDepth(a));
+
+    // Update each parent based on its children's current state
+    for (const parentId of parentNodes) {
+        const node = nodeMap.get(parentId);
+        if (!node?.children?.length) continue;
+
+        let allChecked = true;
+        let anyCheckedOrIndeterminate = false;
+
+        for (const child of node.children) {
+            const isChecked = tempChecked.has(child.id);
+            const isIndeterminate = tempIndeterminate.has(child.id);
+
+            if (isChecked) {
+                anyCheckedOrIndeterminate = true;
+            } else if (isIndeterminate) {
+                anyCheckedOrIndeterminate = true;
+                allChecked = false;
+            } else {
+                allChecked = false;
+            }
+
+            if (!allChecked && anyCheckedOrIndeterminate) break;
+        }
+
+        if (allChecked) {
+            tempChecked.add(parentId);
+            tempIndeterminate.delete(parentId);
+        } else if (anyCheckedOrIndeterminate) {
+            tempChecked.delete(parentId);
+            tempIndeterminate.add(parentId);
+        } else {
+            tempChecked.delete(parentId);
+            tempIndeterminate.delete(parentId);
+        }
+    }
+
+    updateChecked(tempChecked);
+    updateIndeterminate(tempIndeterminate);
+}

--- a/src/hooks/useDragDrop.ts
+++ b/src/hooks/useDragDrop.ts
@@ -1,0 +1,643 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+    Animated,
+    PanResponder,
+    type PanResponderInstance,
+} from "react-native";
+import type { FlashList } from "@shopify/flash-list";
+
+import type { __FlattenedTreeNode__, TreeNode } from "../types/treeView.types";
+import type { DragEndEvent, DropTarget } from "../types/dragDrop.types";
+import { getTreeViewStore } from "../store/treeView.store";
+import { collapseNodes, expandNodes, handleToggleExpand, initializeNodeMaps, recalculateCheckedStates } from "../helpers";
+import { moveTreeNode } from "../helpers/moveTreeNode.helper";
+
+interface UseDragDropParams<ID> {
+    storeId: string;
+    flattenedNodes: __FlattenedTreeNode__<ID>[];
+    flashListRef: React.RefObject<FlashList<__FlattenedTreeNode__<ID>> | null>;
+    containerRef: React.RefObject<{ measureInWindow: (cb: (x: number, y: number, w: number, h: number) => void) => void } | null>;
+    dragEnabled: boolean;
+    onDragEnd?: (event: DragEndEvent<ID>) => void;
+    longPressDuration: number;
+    autoScrollThreshold: number;
+    autoScrollSpeed: number;
+    internalDataRef: React.MutableRefObject<TreeNode<ID>[] | null>;
+    measuredItemHeightRef: React.MutableRefObject<number>;
+    dragOverlayOffset: number;
+    autoExpandDelay: number;
+}
+
+interface UseDragDropReturn<ID> {
+    panResponder: PanResponderInstance;
+    overlayY: Animated.Value;
+    isDragging: boolean;
+    draggedNode: __FlattenedTreeNode__<ID> | null;
+    dropTarget: DropTarget<ID> | null;
+    handleNodeTouchStart: (
+        nodeId: ID,
+        pageY: number,
+        locationY: number,
+        nodeIndex: number,
+    ) => void;
+    cancelLongPressTimer: () => void;
+    scrollOffsetRef: React.MutableRefObject<number>;
+    headerOffsetRef: React.MutableRefObject<number>;
+}
+
+export function useDragDrop<ID>(
+    params: UseDragDropParams<ID>
+): UseDragDropReturn<ID> {
+    const {
+        storeId,
+        flattenedNodes,
+        flashListRef,
+        containerRef,
+        dragEnabled,
+        onDragEnd,
+        longPressDuration,
+        autoScrollThreshold,
+        autoScrollSpeed,
+        internalDataRef,
+        measuredItemHeightRef,
+        dragOverlayOffset,
+        autoExpandDelay,
+    } = params;
+
+    // --- Refs for mutable state (no stale closures in PanResponder) ---
+    const isDraggingRef = useRef(false);
+    const draggedNodeRef = useRef<__FlattenedTreeNode__<ID> | null>(null);
+    const draggedNodeIdRef = useRef<ID | null>(null);
+    const draggedNodeIndexRef = useRef(-1);
+
+    const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const containerPageYRef = useRef(0);
+    const containerHeightRef = useRef(0);
+    const grabOffsetYRef = useRef(0);
+    const scrollOffsetRef = useRef(0);
+    const headerOffsetRef = useRef(0);
+    const itemHeightRef = useRef(36);
+
+    const overlayY = useRef(new Animated.Value(0)).current;
+
+    const autoScrollRAFRef = useRef<number | null>(null);
+    const autoScrollSpeedRef = useRef(0);
+
+    // Delta-based auto-scroll: avoids unreliable containerPageY
+    const initialFingerPageYRef = useRef(0);
+    const initialFingerContainerYRef = useRef(0);
+
+    // Auto-expand timer for hovering over collapsed nodes
+    const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const autoExpandTargetRef = useRef<ID | null>(null);
+    // Track which nodes were auto-expanded during this drag (to collapse on drag end)
+    const autoExpandedDuringDragRef = useRef<Set<ID>>(new Set());
+
+    // Previous drop target for hysteresis (prevents flicker between "below N" / "above N+1")
+    const prevDropTargetRef = useRef<{ targetIndex: number; position: "above" | "below" | "inside" } | null>(null);
+
+    // Keep flattenedNodes ref current for PanResponder closures
+    const flattenedNodesRef = useRef(flattenedNodes);
+    flattenedNodesRef.current = flattenedNodes;
+
+    // Keep callbacks current
+    const onDragEndRef = useRef(onDragEnd);
+    onDragEndRef.current = onDragEnd;
+
+    // --- React state (triggers re-renders only at drag start/end + indicator changes) ---
+    const [isDragging, setIsDragging] = useState(false);
+    const [draggedNode, setDraggedNode] = useState<__FlattenedTreeNode__<ID> | null>(null);
+    const [dropTarget, setDropTarget] = useState<DropTarget<ID> | null>(null);
+
+    // Ref mirror of dropTarget — avoids nesting Zustand updates inside React state updaters
+    const dropTargetRef = useRef<DropTarget<ID> | null>(null);
+
+    // --- Long press timer ---
+    const cancelLongPressTimer = useCallback(() => {
+        if (longPressTimerRef.current) {
+            clearTimeout(longPressTimerRef.current);
+            longPressTimerRef.current = null;
+        }
+    }, []);
+
+    // --- Get all descendant IDs of a node ---
+    const getDescendantIds = useCallback(
+        (nodeId: ID): Set<ID> => {
+            const store = getTreeViewStore<ID>(storeId);
+            const { nodeMap } = store.getState();
+            const descendants = new Set<ID>();
+            const stack: ID[] = [nodeId];
+
+            while (stack.length > 0) {
+                const currentId = stack.pop()!;
+                const node = nodeMap.get(currentId);
+                if (node?.children) {
+                    for (const child of node.children) {
+                        descendants.add(child.id);
+                        stack.push(child.id);
+                    }
+                }
+            }
+            return descendants;
+        },
+        [storeId]
+    );
+
+    // --- Initiate drag ---
+    const initiateDrag = useCallback(
+        (nodeId: ID, pageY: number, locationY: number, nodeIndex: number) => {
+            if (!dragEnabled) return;
+
+            const container = containerRef.current;
+            if (!container) return;
+
+            container.measureInWindow((_x, y, _w, h) => {
+                containerPageYRef.current = y;
+                containerHeightRef.current = h;
+
+                // Find the node in flattened list
+                const nodes = flattenedNodesRef.current;
+                const node = nodes[nodeIndex];
+                if (!node) return;
+
+                // Collapse node if expanded
+                const store = getTreeViewStore<ID>(storeId);
+                const { expanded } = store.getState();
+                if (expanded.has(nodeId) && node.children?.length) {
+                    handleToggleExpand(storeId, nodeId);
+                }
+
+                // Store grab metadata
+                grabOffsetYRef.current = locationY;
+                draggedNodeRef.current = node;
+                draggedNodeIdRef.current = nodeId;
+                draggedNodeIndexRef.current = nodeIndex;
+
+                // Use measured item height if available, fall back to estimatedItemSize
+                const measured = measuredItemHeightRef.current;
+                const estimatedSize =
+                    (flashListRef.current as any)?.props?.estimatedItemSize ?? 36;
+                itemHeightRef.current = measured > 0 ? measured : estimatedSize;
+
+                // Calculate headerOffset dynamically:
+                // fingerLocalY = pageY - containerPageY
+                // fingerLocalY = headerOffset + nodeIndex * itemHeight - scrollOffset + grabOffsetY
+                // So: headerOffset = fingerLocalY + scrollOffset - grabOffsetY - nodeIndex * itemHeight
+                const fingerLocalY = pageY - containerPageYRef.current;
+                headerOffsetRef.current =
+                    fingerLocalY +
+                    scrollOffsetRef.current -
+                    locationY -
+                    nodeIndex * itemHeightRef.current;
+
+                // Delta-based auto-scroll: compute finger's position in the container
+                // from the node's known index (avoids unreliable containerPageY).
+                // The FlashList header (padding:5 → ~10px) + nodeIndex * itemHeight - scroll + locationY
+                const iH = itemHeightRef.current;
+                const listHeaderHeight = 10; // HeaderFooterView has padding: 5 → 10px total
+                initialFingerPageYRef.current = pageY;
+                initialFingerContainerYRef.current =
+                    listHeaderHeight + nodeIndex * iH - scrollOffsetRef.current + locationY;
+
+                // Compute invalid targets (self + descendants)
+                const descendants = getDescendantIds(nodeId);
+                descendants.add(nodeId);
+
+                // Update store (triggers one re-render of nodes to show greyed-out state)
+                store.getState().updateDraggedNodeId(nodeId);
+                store.getState().updateInvalidDragTargetIds(descendants);
+
+                // Set overlay initial position (with configurable offset)
+                const overlayLocalY = fingerLocalY - locationY + dragOverlayOffset * itemHeightRef.current;
+                overlayY.setValue(overlayLocalY);
+
+                // Set React state
+                isDraggingRef.current = true;
+                autoExpandedDuringDragRef.current.clear();
+                setIsDragging(true);
+                setDraggedNode(node);
+                setDropTarget(null);
+
+                // Start auto-scroll loop
+                startAutoScrollLoop();
+            });
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [
+            dragEnabled,
+            storeId,
+            containerRef,
+            flashListRef,
+            getDescendantIds,
+            overlayY,
+        ]
+    );
+
+    // --- Handle node touch start (long press detection) ---
+    const handleNodeTouchStart = useCallback(
+        (nodeId: ID, pageY: number, locationY: number, nodeIndex: number) => {
+            if (!dragEnabled) return;
+
+            // Cancel any existing timer
+            cancelLongPressTimer();
+
+            // Start new timer
+            longPressTimerRef.current = setTimeout(() => {
+                longPressTimerRef.current = null;
+                initiateDrag(nodeId, pageY, locationY, nodeIndex);
+            }, longPressDuration);
+        },
+        [dragEnabled, longPressDuration, cancelLongPressTimer, initiateDrag]
+    );
+
+    // --- Auto-scroll ---
+    const startAutoScrollLoop = useCallback(() => {
+        const loop = () => {
+            if (!isDraggingRef.current) return;
+
+            if (autoScrollSpeedRef.current !== 0) {
+                const newOffset = Math.max(
+                    0,
+                    scrollOffsetRef.current + autoScrollSpeedRef.current
+                );
+                scrollOffsetRef.current = newOffset;
+                (flashListRef.current as any)?.scrollToOffset?.({
+                    offset: newOffset,
+                    animated: false,
+                });
+            }
+
+            autoScrollRAFRef.current = requestAnimationFrame(loop);
+        };
+        autoScrollRAFRef.current = requestAnimationFrame(loop);
+    }, [flashListRef]);
+
+    const stopAutoScroll = useCallback(() => {
+        if (autoScrollRAFRef.current !== null) {
+            cancelAnimationFrame(autoScrollRAFRef.current);
+            autoScrollRAFRef.current = null;
+        }
+        autoScrollSpeedRef.current = 0;
+    }, []);
+
+    const updateAutoScroll = useCallback(
+        (fingerInContainer: number) => {
+            const threshold = autoScrollThreshold;
+            const maxSpeed = 8 * autoScrollSpeed;
+            const containerH = containerHeightRef.current;
+
+            if (fingerInContainer < threshold) {
+                // Scroll up
+                const ratio = 1 - Math.max(0, fingerInContainer) / threshold;
+                autoScrollSpeedRef.current = -maxSpeed * ratio;
+            } else if (fingerInContainer > containerH - threshold) {
+                // Scroll down
+                const ratio =
+                    1 - Math.max(0, containerH - fingerInContainer) / threshold;
+                autoScrollSpeedRef.current = maxSpeed * ratio;
+            } else {
+                autoScrollSpeedRef.current = 0;
+            }
+        },
+        [autoScrollThreshold, autoScrollSpeed]
+    );
+
+    // --- Cancel auto-expand timer ---
+    const cancelAutoExpandTimer = useCallback(() => {
+        if (autoExpandTimerRef.current) {
+            clearTimeout(autoExpandTimerRef.current);
+            autoExpandTimerRef.current = null;
+        }
+        autoExpandTargetRef.current = null;
+    }, []);
+
+    // --- Calculate drop target ---
+    const calculateDropTarget = useCallback(
+        (fingerPageY: number) => {
+            const nodes = flattenedNodesRef.current;
+            if (nodes.length === 0) return;
+
+            const fingerLocalY =
+                fingerPageY - containerPageYRef.current;
+            const fingerContentY =
+                fingerLocalY + scrollOffsetRef.current;
+            const adjustedContentY =
+                fingerContentY - headerOffsetRef.current;
+            const iH = itemHeightRef.current;
+
+            const rawIndex = Math.floor(adjustedContentY / iH);
+            let clampedIndex = Math.max(
+                0,
+                Math.min(rawIndex, nodes.length - 1)
+            );
+            let targetNode = nodes[clampedIndex];
+            if (!targetNode) return;
+
+            // Determine zone within item
+            const positionInItem =
+                (adjustedContentY - clampedIndex * iH) / iH;
+            let position: "above" | "below" | "inside";
+            if (positionInItem < 0.3) {
+                position = "above";
+            } else if (positionInItem > 0.7) {
+                position = "below";
+            } else {
+                position = "inside";
+            }
+
+            // --- Hysteresis: prevent flicker between "below N" and "above N+1" ---
+            // These two positions represent the same visual gap between nodes.
+            // Keep the previous one to avoid the indicator jumping between nodes.
+            const prev = prevDropTargetRef.current;
+            if (prev) {
+                const sameGap =
+                    (prev.position === "below" && position === "above" &&
+                        prev.targetIndex === clampedIndex - 1) ||
+                    (prev.position === "above" && position === "below" &&
+                        clampedIndex === prev.targetIndex - 1);
+                if (sameGap) {
+                    // Keep previous target — they're at the same visual gap
+                    return;
+                }
+            }
+            prevDropTargetRef.current = { targetIndex: clampedIndex, position };
+
+            const indicatorTop = fingerLocalY - grabOffsetYRef.current;
+
+            // Validity check
+            const store = getTreeViewStore<ID>(storeId);
+            const { invalidDragTargetIds, draggedNodeId, expanded } =
+                store.getState();
+            const isValid =
+                targetNode.id !== draggedNodeId &&
+                !invalidDragTargetIds.has(targetNode.id);
+
+            // --- Auto-expand: if hovering "inside" a collapsed expandable node ---
+            if (isValid && position === "inside" && targetNode.children?.length && !expanded.has(targetNode.id)) {
+                if (autoExpandTargetRef.current !== targetNode.id) {
+                    // New hover target — start timer
+                    cancelAutoExpandTimer();
+                    autoExpandTargetRef.current = targetNode.id;
+                    autoExpandTimerRef.current = setTimeout(() => {
+                        autoExpandTimerRef.current = null;
+                        // Expand the node and track it
+                        handleToggleExpand(storeId, targetNode.id);
+                        autoExpandedDuringDragRef.current.add(targetNode.id);
+                    }, autoExpandDelay);
+                }
+            } else {
+                // Not hovering inside a collapsed expandable node — cancel timer
+                if (autoExpandTargetRef.current !== null) {
+                    cancelAutoExpandTimer();
+                }
+            }
+
+            const newTarget: DropTarget<ID> = {
+                targetNodeId: targetNode.id,
+                targetIndex: clampedIndex,
+                position,
+                isValid,
+                targetLevel: targetNode.level ?? 0,
+                indicatorTop,
+            };
+
+            // Update the store so each Node can render its own indicator
+            if (isValid) {
+                store.getState().updateDropTarget(targetNode.id, position);
+            } else {
+                store.getState().updateDropTarget(null, null);
+            }
+
+            // Keep ref in sync (used by handleDragEnd to avoid setState-during-render)
+            dropTargetRef.current = newTarget;
+
+            setDropTarget((prevTarget) => {
+                if (
+                    prevTarget?.targetNodeId === newTarget.targetNodeId &&
+                    prevTarget?.position === newTarget.position &&
+                    prevTarget?.isValid === newTarget.isValid &&
+                    prevTarget?.indicatorTop === newTarget.indicatorTop
+                ) {
+                    return prevTarget;
+                }
+                return newTarget;
+            });
+        },
+        [storeId, autoExpandDelay, cancelAutoExpandTimer]
+    );
+
+    // --- Handle drag end ---
+    const handleDragEnd = useCallback(
+        (fingerPageY?: number) => {
+            stopAutoScroll();
+            cancelLongPressTimer();
+            cancelAutoExpandTimer();
+            prevDropTargetRef.current = null;
+
+            if (!isDraggingRef.current) return;
+            isDraggingRef.current = false;
+
+            // Recalculate drop target at final position if we have a pageY
+            if (fingerPageY !== undefined) {
+                calculateDropTarget(fingerPageY);
+            }
+
+            // Cancel any auto-expand timer that calculateDropTarget may have just started.
+            // Without this, the timer fires after drag ends and toggles the target back to collapsed.
+            cancelAutoExpandTimer();
+
+            // Read current drop target from ref via a small delay to ensure
+            // the last setDropTarget has been processed
+            // We use the current dropTarget state via a callback
+            // Read drop target from ref (avoids nesting Zustand updates inside React state updaters)
+            const currentTarget = dropTargetRef.current;
+            const droppedNodeId = draggedNodeIdRef.current;
+
+            if (
+                currentTarget?.isValid &&
+                droppedNodeId !== null
+            ) {
+                const store = getTreeViewStore<ID>(storeId);
+                const currentData =
+                    store.getState().initialTreeViewData;
+                const newData = moveTreeNode(
+                    currentData,
+                    droppedNodeId,
+                    currentTarget.targetNodeId,
+                    currentTarget.position
+                );
+
+                // Update store directly (preserves checked/expanded)
+                store
+                    .getState()
+                    .updateInitialTreeViewData(newData);
+                initializeNodeMaps(storeId, newData);
+
+                // Recalculate checked/indeterminate states for all parents
+                // since the tree structure changed
+                recalculateCheckedStates<ID>(storeId);
+
+                // If dropped "inside" a node, expand it so the dropped node is visible
+                if (currentTarget.position === "inside") {
+                    expandNodes(storeId, [currentTarget.targetNodeId]);
+                }
+
+                // Expand ancestors of the dropped node so it's visible
+                expandNodes(storeId, [droppedNodeId], true);
+
+                // Set internal data ref to prevent useDeepCompareEffect
+                // from reinitializing
+                internalDataRef.current = newData;
+
+                // Notify consumer
+                onDragEndRef.current?.({
+                    draggedNodeId: droppedNodeId,
+                    targetNodeId: currentTarget.targetNodeId,
+                    position: currentTarget.position,
+                    newTreeData: newData,
+                });
+
+                // Scroll to the dropped node after React processes the expansion
+                setTimeout(() => {
+                    const nodes = flattenedNodesRef.current;
+                    const idx = nodes.findIndex(n => n.id === droppedNodeId);
+                    if (idx >= 0) {
+                        flashListRef.current?.scrollToIndex?.({
+                            index: idx,
+                            animated: true,
+                            viewPosition: 0.5,
+                        });
+                    }
+                }, 100);
+            }
+
+            // Collapse auto-expanded nodes that aren't ancestors of the drop target
+            if (autoExpandedDuringDragRef.current.size > 0) {
+                const store3 = getTreeViewStore<ID>(storeId);
+                const { childToParentMap } = store3.getState();
+
+                // Collect ancestors of the drop target (keep these expanded)
+                const ancestorIds = new Set<ID>();
+                if (currentTarget?.isValid) {
+                    let walkId: ID | undefined = currentTarget.targetNodeId;
+                    while (walkId !== undefined) {
+                        ancestorIds.add(walkId);
+                        walkId = childToParentMap.get(walkId);
+                    }
+                }
+
+                // Collapse auto-expanded nodes that aren't in the ancestor chain
+                const toCollapse: ID[] = [];
+                for (const nodeId of autoExpandedDuringDragRef.current) {
+                    if (!ancestorIds.has(nodeId)) {
+                        toCollapse.push(nodeId);
+                    }
+                }
+                if (toCollapse.length > 0) {
+                    collapseNodes(storeId, toCollapse);
+                }
+                autoExpandedDuringDragRef.current.clear();
+            }
+
+            // Clear drag state
+            const store2 = getTreeViewStore<ID>(storeId);
+            store2.getState().updateDraggedNodeId(null);
+            store2.getState().updateInvalidDragTargetIds(new Set());
+            store2.getState().updateDropTarget(null, null);
+
+            // Reset all refs
+            dropTargetRef.current = null;
+            draggedNodeRef.current = null;
+            draggedNodeIdRef.current = null;
+            draggedNodeIndexRef.current = -1;
+
+            setDropTarget(null);
+            setIsDragging(false);
+            setDraggedNode(null);
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [
+            storeId,
+            stopAutoScroll,
+            cancelLongPressTimer,
+            cancelAutoExpandTimer,
+            calculateDropTarget,
+            internalDataRef,
+        ]
+    );
+
+    // --- PanResponder ---
+    const panResponder = useRef(
+        PanResponder.create({
+            onStartShouldSetPanResponder: () => false,
+            onStartShouldSetPanResponderCapture: () =>
+                isDraggingRef.current,
+            onMoveShouldSetPanResponder: () => isDraggingRef.current,
+            onMoveShouldSetPanResponderCapture: () =>
+                isDraggingRef.current,
+
+            onPanResponderGrant: () => {
+                // Touch captured successfully
+            },
+
+            onPanResponderMove: (evt) => {
+                if (!isDraggingRef.current) return;
+
+                const fingerPageY = evt.nativeEvent.pageY;
+                const fingerLocalY =
+                    fingerPageY - containerPageYRef.current;
+
+                // Update overlay position (with configurable offset)
+                const overlayLocalY =
+                    fingerLocalY - grabOffsetYRef.current + dragOverlayOffset * itemHeightRef.current;
+                overlayY.setValue(overlayLocalY);
+
+                // Calculate drop target
+                calculateDropTarget(fingerPageY);
+
+                // Auto-scroll at edges — use delta-based position relative to container
+                const fingerInContainer =
+                    initialFingerContainerYRef.current +
+                    (fingerPageY - initialFingerPageYRef.current);
+                updateAutoScroll(fingerInContainer);
+            },
+
+            onPanResponderRelease: (evt) => {
+                handleDragEnd(evt.nativeEvent.pageY);
+            },
+
+            onPanResponderTerminate: () => {
+                handleDragEnd();
+            },
+        })
+    ).current;
+
+    // --- Cleanup on unmount ---
+    useEffect(() => {
+        return () => {
+            cancelLongPressTimer();
+            cancelAutoExpandTimer();
+            stopAutoScroll();
+            if (isDraggingRef.current) {
+                isDraggingRef.current = false;
+                const store = getTreeViewStore<ID>(storeId);
+                store.getState().updateDraggedNodeId(null);
+                store.getState().updateInvalidDragTargetIds(new Set());
+                store.getState().updateDropTarget(null, null);
+            }
+        };
+    }, [storeId, cancelLongPressTimer, cancelAutoExpandTimer, stopAutoScroll]);
+
+    return {
+        panResponder,
+        overlayY,
+        isDragging,
+        draggedNode,
+        dropTarget,
+        handleNodeTouchStart,
+        cancelLongPressTimer,
+        scrollOffsetRef,
+        headerOffsetRef,
+    };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,11 +8,21 @@ import type {
     CheckBoxViewProps,
     CheckboxValueType,
     BuiltInCheckBoxViewStyleProps,
-    SelectionPropagation
+    SelectionPropagation,
+    DragDropCustomizations,
+    DragOverlayStyleProps,
+    DragOverlayComponentProps,
+    DropIndicatorStyleProps,
+    DropIndicatorComponentProps,
 } from "./types/treeView.types";
+import type {
+    DragEndEvent,
+    DropPosition
+} from "./types/dragDrop.types";
 
 export * from "./TreeView";
 export * from "./components/CheckboxView";
+export { moveTreeNode } from "./helpers/moveTreeNode.helper";
 
 export type {
     TreeNode,
@@ -24,5 +34,12 @@ export type {
     CheckBoxViewProps,
     CheckboxValueType,
     BuiltInCheckBoxViewStyleProps,
-    SelectionPropagation
+    SelectionPropagation,
+    DragEndEvent,
+    DropPosition,
+    DragDropCustomizations,
+    DragOverlayStyleProps,
+    DragOverlayComponentProps,
+    DropIndicatorStyleProps,
+    DropIndicatorComponentProps,
 };

--- a/src/store/treeView.store.ts
+++ b/src/store/treeView.store.ts
@@ -1,4 +1,5 @@
 import type { SelectionPropagation, TreeNode } from "../types/treeView.types";
+import type { DropPosition } from "../types/dragDrop.types";
 import { create, type StoreApi, type UseBoundStore } from "zustand";
 
 export type TreeViewState<ID> = {
@@ -42,6 +43,18 @@ export type TreeViewState<ID> = {
     setSelectionPropagation: (
         selectionPropagation: SelectionPropagation
     ) => void;
+
+    // Drag-and-drop state
+    draggedNodeId: ID | null;
+    updateDraggedNodeId: (draggedNodeId: ID | null) => void;
+
+    invalidDragTargetIds: Set<ID>;
+    updateInvalidDragTargetIds: (invalidDragTargetIds: Set<ID>) => void;
+
+    // Drop target state (used by nodes to render their own indicator)
+    dropTargetNodeId: ID | null;
+    dropPosition: DropPosition | null;
+    updateDropTarget: (nodeId: ID | null, position: DropPosition | null) => void;
 
     // Cleanup all states in this store
     cleanUpTreeViewStore: () => void;
@@ -97,6 +110,21 @@ export function getTreeViewStore<ID>(id: string): UseBoundStore<StoreApi<TreeVie
                 }
             }),
 
+            draggedNodeId: null,
+            updateDraggedNodeId: (draggedNodeId) => set({ draggedNodeId }),
+
+            invalidDragTargetIds: new Set<ID>(),
+            updateInvalidDragTargetIds: (invalidDragTargetIds) => set({
+                invalidDragTargetIds
+            }),
+
+            dropTargetNodeId: null,
+            dropPosition: null,
+            updateDropTarget: (nodeId, position) => set({
+                dropTargetNodeId: nodeId,
+                dropPosition: position,
+            }),
+
             cleanUpTreeViewStore: () =>
                 set({
                     checked: new Set(),
@@ -109,6 +137,10 @@ export function getTreeViewStore<ID>(id: string): UseBoundStore<StoreApi<TreeVie
                     searchKeys: [""],
                     innerMostChildrenIds: [],
                     selectionPropagation: { toChildren: true, toParents: true },
+                    draggedNodeId: null,
+                    invalidDragTargetIds: new Set<ID>(),
+                    dropTargetNodeId: null,
+                    dropPosition: null,
                 }),
         }));
 

--- a/src/types/dragDrop.types.ts
+++ b/src/types/dragDrop.types.ts
@@ -1,0 +1,23 @@
+import type { TreeNode } from "./treeView.types";
+
+export type DropPosition = "above" | "below" | "inside";
+
+export interface DragEndEvent<ID = string> {
+    /** The id of the node that was dragged */
+    draggedNodeId: ID;
+    /** The id of the target node where the dragged node was dropped */
+    targetNodeId: ID;
+    /** Where relative to the target: above/below = sibling, inside = child */
+    position: DropPosition;
+    /** The reordered tree data after the move */
+    newTreeData: TreeNode<ID>[];
+}
+
+export interface DropTarget<ID = string> {
+    targetNodeId: ID;
+    targetIndex: number;
+    position: DropPosition;
+    isValid: boolean;
+    targetLevel: number;
+    indicatorTop: number;
+}

--- a/src/types/treeView.types.ts
+++ b/src/types/treeView.types.ts
@@ -12,6 +12,7 @@ import type {
 import type {
     CheckboxProps as _CheckboxProps
 } from "@futurejj/react-native-checkbox";
+import type { DragEndEvent, DropPosition } from "./dragDrop.types";
 
 export type CheckboxValueType = boolean | "indeterminate";
 
@@ -46,6 +47,10 @@ export interface NodeRowProps<ID = string> {
 
     onCheck: () => void;
     onExpand: () => void;
+
+    isDragTarget?: boolean;
+    isDragging?: boolean;
+    isDraggedNode?: boolean;
 }
 
 export interface TreeItemCustomizations<ID> {
@@ -64,6 +69,20 @@ export interface NodeProps<ID> extends TreeItemCustomizations<ID> {
     node: __FlattenedTreeNode__<ID>;
     level: number;
     storeId: string;
+
+    nodeIndex?: number;
+    dragEnabled?: boolean;
+    isDragging?: boolean;
+    onNodeTouchStart?: (
+        nodeId: ID,
+        pageY: number,
+        locationY: number,
+        nodeIndex: number
+    ) => void;
+    onNodeTouchEnd?: () => void;
+    longPressDuration?: number;
+    onItemLayout?: (height: number) => void;
+    dragDropCustomizations?: DragDropCustomizations<ID>;
 }
 
 export interface NodeListProps<ID> extends TreeItemCustomizations<ID> {
@@ -73,6 +92,18 @@ export interface NodeListProps<ID> extends TreeItemCustomizations<ID> {
     initialScrollNodeID?: ID;
 
     storeId: string;
+
+    dragEnabled?: boolean;
+    onDragEnd?: (event: DragEndEvent<ID>) => void;
+    longPressDuration?: number;
+    autoScrollThreshold?: number;
+    autoScrollSpeed?: number;
+    /** Offset of the dragged overlay from the finger, in item-height units. Default: -1 (one item above finger) */
+    dragOverlayOffset?: number;
+    /** Delay in ms before auto-expanding a collapsed node during drag hover. Default: 800 */
+    autoExpandDelay?: number;
+    /** Customizations for drag-and-drop visuals (overlay, indicator, opacity) */
+    dragDropCustomizations?: DragDropCustomizations<ID>;
 }
 
 export interface TreeViewProps<ID = string> extends Omit<
@@ -88,6 +119,21 @@ export interface TreeViewProps<ID = string> extends Omit<
     preExpandedIds?: ID[];
 
     selectionPropagation?: SelectionPropagation;
+
+    /** Enable drag-and-drop reordering */
+    dragEnabled?: boolean;
+    /** Callback fired after a node is dropped at a new position */
+    onDragEnd?: (event: DragEndEvent<ID>) => void;
+    /** Long press duration in ms to start drag. Default: 400 */
+    longPressDuration?: number;
+    /** Distance from edge (px) to trigger auto-scroll. Default: 60 */
+    autoScrollThreshold?: number;
+    /** Speed multiplier for auto-scroll. Default: 1.0 */
+    autoScrollSpeed?: number;
+    /** Offset of the dragged overlay from the finger, in item-height units. Default: -1 (one item above finger) */
+    dragOverlayOffset?: number;
+    /** Delay in ms before auto-expanding a collapsed node during drag hover. Default: 800 */
+    autoExpandDelay?: number;
 }
 
 type CheckboxProps = Omit<_CheckboxProps, "onPress" | "status">;
@@ -140,4 +186,64 @@ export interface TreeViewRef<ID = string> {
 export interface SelectionPropagation {
     toChildren?: boolean;
     toParents?: boolean;
+}
+
+// --- Drag-and-drop customization types ---
+
+/** Props for the drop indicator rendered on the target node during drag */
+export interface DropIndicatorComponentProps {
+    /** Whether the indicator is above, below, or inside the target node */
+    position: DropPosition;
+}
+
+/** Style props for customizing the built-in drop indicator appearance */
+export interface DropIndicatorStyleProps {
+    /** Color of the line indicator (above/below). Default: "#0078FF" */
+    lineColor?: string;
+    /** Thickness of the line indicator. Default: 3 */
+    lineThickness?: number;
+    /** Diameter of the circle at the line's start. Default: 10 */
+    circleSize?: number;
+    /** Background color of the "inside" highlight. Default: "rgba(0, 120, 255, 0.15)" */
+    highlightColor?: string;
+    /** Border color of the "inside" highlight. Default: "rgba(0, 120, 255, 0.5)" */
+    highlightBorderColor?: string;
+}
+
+/** Style props for customizing the drag overlay (the "lifted" node ghost) */
+export interface DragOverlayStyleProps {
+    /** Background color of the overlay. Default: "rgba(255, 255, 255, 0.95)" */
+    backgroundColor?: string;
+    /** Shadow color. Default: "#000" */
+    shadowColor?: string;
+    /** Shadow opacity. Default: 0.25 */
+    shadowOpacity?: number;
+    /** Shadow radius. Default: 4 */
+    shadowRadius?: number;
+    /** Android elevation. Default: 10 */
+    elevation?: number;
+    /** Custom style applied to the overlay container */
+    style?: StyleProp<ViewStyle>;
+}
+
+/** Combined drag-and-drop customization props */
+export interface DragDropCustomizations<ID> {
+    /** Opacity applied to the dragged node and its invalid drop targets. Default: 0.3 */
+    draggedNodeOpacity?: number;
+    /** Style props for the built-in drop indicator */
+    dropIndicatorStyleProps?: DropIndicatorStyleProps;
+    /** Style props for the drag overlay (lifted node ghost) */
+    dragOverlayStyleProps?: DragOverlayStyleProps;
+    /** Fully custom drop indicator component — replaces the built-in line/highlight */
+    CustomDropIndicatorComponent?: React.ComponentType<DropIndicatorComponentProps>;
+    /** Fully custom drag overlay component — replaces the built-in ghost node */
+    CustomDragOverlayComponent?: React.ComponentType<DragOverlayComponentProps<ID>>;
+}
+
+/** Props passed to a custom drag overlay component */
+export interface DragOverlayComponentProps<ID = string> {
+    /** The node being dragged */
+    node: __FlattenedTreeNode__<ID>;
+    /** The nesting level of the dragged node */
+    level: number;
 }

--- a/src/types/treeView.types.ts
+++ b/src/types/treeView.types.ts
@@ -227,7 +227,7 @@ export interface DragOverlayStyleProps {
 }
 
 /** Combined drag-and-drop customization props */
-export interface DragDropCustomizations<ID> {
+export interface DragDropCustomizations<ID = string> {
     /** Opacity applied to the dragged node and its invalid drop targets. Default: 0.3 */
     draggedNodeOpacity?: number;
     /** Style props for the built-in drop indicator */

--- a/yarn.lock
+++ b/yarn.lock
@@ -16451,8 +16451,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.12.1":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -16461,7 +16461,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
+  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,7 +69,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:7.10.4, @babel/code-frame@npm:~7.10.4":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.20.0, @babel/code-frame@npm:^7.24.7, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/code-frame@npm:7.29.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/d34cc504e7765dfb576a663d97067afb614525806b5cad1a5cc1a7183b916fec8ff57fa233585e3926fd5a9e6b31aae6df91aa81ae9775fb7a28f658d3346f0d
+  languageName: node
+  linkType: hard
+
+"@babel/code-frame@npm:~7.10.4":
   version: 7.10.4
   resolution: "@babel/code-frame@npm:7.10.4"
   dependencies:
@@ -78,50 +89,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.24.7, @babel/code-frame@npm:^7.26.2, @babel/code-frame@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/code-frame@npm:7.27.1"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-    js-tokens: "npm:^4.0.0"
-    picocolors: "npm:^1.1.1"
-  checksum: 10c0/5dd9a18baa5fce4741ba729acc3a3272c49c25cb8736c4b18e113099520e7ef7b545a4096a26d600e4416157e63e87d66db46aa3fbf0a5f2286da2705c12da00
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.27.2, @babel/compat-data@npm:^7.27.7, @babel/compat-data@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/compat-data@npm:7.28.5"
-  checksum: 10c0/702a25de73087b0eba325c1d10979eed7c9b6662677386ba7b5aa6eace0fc0676f78343bae080a0176ae26f58bd5535d73b9d0fbb547fef377692e8b249353a7
+"@babel/compat-data@npm:^7.28.6, @babel/compat-data@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/compat-data@npm:7.29.0"
+  checksum: 10c0/08f348554989d23aa801bf1405aa34b15e841c0d52d79da7e524285c77a5f9d298e70e11d91cc578d8e2c9542efc586d50c5f5cf8e1915b254a9dcf786913a94
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.14.0, @babel/core@npm:^7.20.0, @babel/core@npm:^7.23.9, @babel/core@npm:^7.24.7, @babel/core@npm:^7.25.2":
-  version: 7.28.5
-  resolution: "@babel/core@npm:7.28.5"
+  version: 7.29.0
+  resolution: "@babel/core@npm:7.29.0"
   dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.5"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-module-transforms": "npm:^7.28.3"
-    "@babel/helpers": "npm:^7.28.4"
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.28.5"
-    "@babel/types": "npm:^7.28.5"
+    "@babel/code-frame": "npm:^7.29.0"
+    "@babel/generator": "npm:^7.29.0"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
+    "@babel/helper-module-transforms": "npm:^7.28.6"
+    "@babel/helpers": "npm:^7.28.6"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
     "@jridgewell/remapping": "npm:^2.3.5"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10c0/535f82238027621da6bdffbdbe896ebad3558b311d6f8abc680637a9859b96edbf929ab010757055381570b29cf66c4a295b5618318d27a4273c0e2033925e72
+  checksum: 10c0/5127d2e8e842ae409e11bcbb5c2dff9874abf5415e8026925af7308e903f4f43397341467a130490d1a39884f461bc2b67f3063bce0be44340db89687fd852aa
   languageName: node
   linkType: hard
 
 "@babel/eslint-parser@npm:^7.18.2":
-  version: 7.28.5
-  resolution: "@babel/eslint-parser@npm:7.28.5"
+  version: 7.28.6
+  resolution: "@babel/eslint-parser@npm:7.28.6"
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals": "npm:5.1.1-v1"
     eslint-visitor-keys: "npm:^2.1.0"
@@ -129,20 +129,20 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.11.0
     eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
-  checksum: 10c0/4d13f765434b6be83ab3917f06ad712dedf0d5bfa80fe54cd6cea44adac6a0d2519020ad307d66b4490e46a435874829eac6a9fd3a9cad54d7616c47d288aaed
+  checksum: 10c0/58a85f67a056ba8389978c4654b690b890a6dcd19aa9655c5d7d9349a0c25f124cabad8a190b6bf7045a063aeee1b8e2ab23cfe4d8fa0e0517716a8b70e758bc
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.28.5, @babel/generator@npm:^7.7.2":
-  version: 7.28.5
-  resolution: "@babel/generator@npm:7.28.5"
+"@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.29.0, @babel/generator@npm:^7.7.2":
+  version: 7.29.1
+  resolution: "@babel/generator@npm:7.29.1"
   dependencies:
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/types": "npm:^7.28.5"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
     "@jridgewell/gen-mapping": "npm:^0.3.12"
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
-  checksum: 10c0/9f219fe1d5431b6919f1a5c60db8d5d34fe546c0d8f5a8511b32f847569234ffc8032beb9e7404649a143f54e15224ecb53a3d11b6bb85c3203e573d91fca752
+  checksum: 10c0/349086e6876258ef3fb2823030fee0f6c0eb9c3ebe35fc572e16997f8c030d765f636ddc6299edae63e760ea6658f8ee9a2edfa6d6b24c9a80c917916b973551
   languageName: node
   linkType: hard
 
@@ -155,37 +155,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.27.1, @babel/helper-compilation-targets@npm:^7.27.2":
-  version: 7.27.2
-  resolution: "@babel/helper-compilation-targets@npm:7.27.2"
+"@babel/helper-compilation-targets@npm:^7.27.1, @babel/helper-compilation-targets@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
   dependencies:
-    "@babel/compat-data": "npm:^7.27.2"
+    "@babel/compat-data": "npm:^7.28.6"
     "@babel/helper-validator-option": "npm:^7.27.1"
     browserslist: "npm:^4.24.0"
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
-  checksum: 10c0/f338fa00dcfea931804a7c55d1a1c81b6f0a09787e528ec580d5c21b3ecb3913f6cb0f361368973ce953b824d910d3ac3e8a8ee15192710d3563826447193ad1
+  checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.27.1, @babel/helper-create-class-features-plugin@npm:^7.28.3, @babel/helper-create-class-features-plugin@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/helper-create-class-features-plugin@npm:7.28.5"
+"@babel/helper-create-class-features-plugin@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.28.6"
   dependencies:
     "@babel/helper-annotate-as-pure": "npm:^7.27.3"
     "@babel/helper-member-expression-to-functions": "npm:^7.28.5"
     "@babel/helper-optimise-call-expression": "npm:^7.27.1"
-    "@babel/helper-replace-supers": "npm:^7.27.1"
+    "@babel/helper-replace-supers": "npm:^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.5"
+    "@babel/traverse": "npm:^7.28.6"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/786a6514efcf4514aaad85beed419b9184d059f4c9a9a95108f320142764999827252a851f7071de19f29424d369616573ecbaa347f1ce23fb12fc6827d9ff56
+  checksum: 10c0/0b62b46717891f4366006b88c9b7f277980d4f578c4c3789b7a4f5a2e09e121de4cda9a414ab403986745cd3ad1af3fe2d948c9f78ab80d4dc085afc9602af50
   languageName: node
   linkType: hard
 
-"@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.27.1":
+"@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.27.1, @babel/helper-create-regexp-features-plugin@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-create-regexp-features-plugin@npm:7.28.5"
   dependencies:
@@ -198,18 +198,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-define-polyfill-provider@npm:^0.6.5":
-  version: 0.6.5
-  resolution: "@babel/helper-define-polyfill-provider@npm:0.6.5"
+"@babel/helper-define-polyfill-provider@npm:^0.6.5, @babel/helper-define-polyfill-provider@npm:^0.6.8":
+  version: 0.6.8
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.6.8"
   dependencies:
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    debug: "npm:^4.4.1"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    debug: "npm:^4.4.3"
     lodash.debounce: "npm:^4.0.8"
-    resolve: "npm:^1.22.10"
+    resolve: "npm:^1.22.11"
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 10c0/4886a068d9ca1e70af395340656a9dda33c50502c67eed39ff6451785f370bdfc6e57095b90cb92678adcd4a111ca60909af53d3a741120719c5604346ae409e
+  checksum: 10c0/306a169f2cb285f368578219ef18ea9702860d3d02d64334f8d45ea38648be0b9e1edad8c8f732fa34bb4206ccbb9883c395570fd57ab7bbcf293bc5964c5b3a
   languageName: node
   linkType: hard
 
@@ -220,7 +220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-member-expression-to-functions@npm:^7.27.1, @babel/helper-member-expression-to-functions@npm:^7.28.5":
+"@babel/helper-member-expression-to-functions@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-member-expression-to-functions@npm:7.28.5"
   dependencies:
@@ -230,26 +230,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.25.9, @babel/helper-module-imports@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-module-imports@npm:7.27.1"
+"@babel/helper-module-imports@npm:^7.25.9, @babel/helper-module-imports@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-module-imports@npm:7.28.6"
   dependencies:
-    "@babel/traverse": "npm:^7.27.1"
-    "@babel/types": "npm:^7.27.1"
-  checksum: 10c0/e00aace096e4e29290ff8648455c2bc4ed982f0d61dbf2db1b5e750b9b98f318bf5788d75a4f974c151bd318fd549e81dbcab595f46b14b81c12eda3023f51e8
+    "@babel/traverse": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
+  checksum: 10c0/b49d8d8f204d9dbfd5ac70c54e533e5269afb3cea966a9d976722b13e9922cc773a653405f53c89acb247d5aebdae4681d631a3ae3df77ec046b58da76eda2ac
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.3":
-  version: 7.28.3
-  resolution: "@babel/helper-module-transforms@npm:7.28.3"
+"@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-module-transforms@npm:7.28.6"
   dependencies:
-    "@babel/helper-module-imports": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.3"
+    "@babel/helper-module-imports": "npm:^7.28.6"
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+    "@babel/traverse": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/549be62515a6d50cd4cfefcab1b005c47f89bd9135a22d602ee6a5e3a01f27571868ada10b75b033569f24dc4a2bb8d04bfa05ee75c16da7ade2d0db1437fcdb
+  checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
   languageName: node
   linkType: hard
 
@@ -262,10 +262,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.8.0":
-  version: 7.27.1
-  resolution: "@babel/helper-plugin-utils@npm:7.27.1"
-  checksum: 10c0/94cf22c81a0c11a09b197b41ab488d416ff62254ce13c57e62912c85700dc2e99e555225787a4099ff6bae7a1812d622c80fbaeda824b79baa10a6c5ac4cf69b
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
+  version: 7.28.6
+  resolution: "@babel/helper-plugin-utils@npm:7.28.6"
+  checksum: 10c0/3f5f8acc152fdbb69a84b8624145ff4f9b9f6e776cb989f9f968f8606eb7185c5c3cfcf3ba08534e37e1e0e1c118ac67080610333f56baa4f7376c99b5f1143d
   languageName: node
   linkType: hard
 
@@ -282,16 +282,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-replace-supers@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-replace-supers@npm:7.27.1"
+"@babel/helper-replace-supers@npm:^7.27.1, @babel/helper-replace-supers@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/helper-replace-supers@npm:7.28.6"
   dependencies:
-    "@babel/helper-member-expression-to-functions": "npm:^7.27.1"
+    "@babel/helper-member-expression-to-functions": "npm:^7.28.5"
     "@babel/helper-optimise-call-expression": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.27.1"
+    "@babel/traverse": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/4f2eaaf5fcc196580221a7ccd0f8873447b5d52745ad4096418f6101a1d2e712e9f93722c9a32bc9769a1dc197e001f60d6f5438d4dfde4b9c6a9e4df719354c
+  checksum: 10c0/04663c6389551b99b8c3e7ba4e2638b8ca2a156418c26771516124c53083aa8e74b6a45abe5dd46360af79709a0e9c6b72c076d0eab9efecdd5aaf836e79d8d5
   languageName: node
   linkType: hard
 
@@ -312,7 +312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.25.9, @babel/helper-validator-identifier@npm:^7.27.1, @babel/helper-validator-identifier@npm:^7.28.5":
+"@babel/helper-validator-identifier@npm:^7.25.9, @babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
@@ -327,23 +327,23 @@ __metadata:
   linkType: hard
 
 "@babel/helper-wrap-function@npm:^7.27.1":
-  version: 7.28.3
-  resolution: "@babel/helper-wrap-function@npm:7.28.3"
+  version: 7.28.6
+  resolution: "@babel/helper-wrap-function@npm:7.28.6"
   dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.28.3"
-    "@babel/types": "npm:^7.28.2"
-  checksum: 10c0/aecb8a457efd893dc3c6378ab9221d06197573fb2fe64afabe7923e7732607d59b07f4c5603909877d69bea3ee87025f4b1d8e4f0403ae0a07b14e9ce0bf355a
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
+  checksum: 10c0/110674c7aa705dd8cc34f278628f540b37a4cb35e81fcaf557772e026a6fd95f571feb51a8efb146e4e91bbf567dc9dd7f534f78da80f55f4be2ec842f36b678
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.28.4":
-  version: 7.28.4
-  resolution: "@babel/helpers@npm:7.28.4"
+"@babel/helpers@npm:^7.28.6":
+  version: 7.29.2
+  resolution: "@babel/helpers@npm:7.29.2"
   dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.4"
-  checksum: 10c0/aaa5fb8098926dfed5f223adf2c5e4c7fbba4b911b73dfec2d7d3083f8ba694d201a206db673da2d9b3ae8c01793e795767654558c450c8c14b4c2175b4fcb44
+    "@babel/template": "npm:^7.28.6"
+    "@babel/types": "npm:^7.29.0"
+  checksum: 10c0/dab0e65b9318b2502a62c58bc0913572318595eec0482c31f0ad416b72636e6698a1d7c57cd2791d4528eb8c548bca88d338dc4d2a55a108dc1f6702f9bc5512
   languageName: node
   linkType: hard
 
@@ -359,14 +359,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/parser@npm:7.28.5"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.9, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
+  version: 7.29.2
+  resolution: "@babel/parser@npm:7.29.2"
   dependencies:
-    "@babel/types": "npm:^7.28.5"
+    "@babel/types": "npm:^7.29.0"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/5bbe48bf2c79594ac02b490a41ffde7ef5aa22a9a88ad6bcc78432a6ba8a9d638d531d868bd1f104633f1f6bba9905746e15185b8276a3756c42b765d131b1ef
+  checksum: 10c0/e5a4e69e3ac7acdde995f37cf299a68458cfe7009dff66bd0962fd04920bef287201169006af365af479c08ff216bfefbb595e331f87f6ae7283858aebbc3317
   languageName: node
   linkType: hard
 
@@ -417,28 +417,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:^7.28.3":
-  version: 7.28.3
-  resolution: "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:7.28.3"
+"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.3"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/3cdc27c4e08a632a58e62c6017369401976edf1cd9ae73fd9f0d6770ddd9accf40b494db15b66bab8db2a8d5dc5bab5ca8c65b19b81fdca955cd8cbbe24daadb
+  checksum: 10c0/f1a9194e8d1742081def7af748e9249eb5082c25d0ced292720a1f054895f99041c764a05f45af669a2c8898aeb79266058aedb0d3e1038963ad49be8288918a
   languageName: node
   linkType: hard
 
 "@babel/plugin-proposal-decorators@npm:^7.12.9":
-  version: 7.28.0
-  resolution: "@babel/plugin-proposal-decorators@npm:7.28.0"
+  version: 7.29.0
+  resolution: "@babel/plugin-proposal-decorators@npm:7.29.0"
   dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/plugin-syntax-decorators": "npm:^7.27.1"
+    "@babel/helper-create-class-features-plugin": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/plugin-syntax-decorators": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/e399f3adc4278560d15fd80691c7a9b644f46e50fa90746f9f3b9ac02cf955ef2b6677277d97c97a4bd6d6a777821fdedf1318923632a439cba1c05e8e59246c
+  checksum: 10c0/b397506fb245374544e2c52909dcbd2193b0327594e3493ea4a47d8a22f6991a90128900d6ee3b129be5246ee08b0d07c8796cfb60502aacf20ac52cc6a92b68
   languageName: node
   linkType: hard
 
@@ -506,14 +506,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-decorators@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-decorators@npm:7.27.1"
+"@babel/plugin-syntax-decorators@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-decorators@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/46ef933bae10b02a8f8603b2f424ecbe23e134a133205bee7c0902dae3021c183a683964cab41ea5433820aa05be0f6f36243551f68a1d94e02ac082cec87aa1
+  checksum: 10c0/bd12119646f65e156709d1d6f4949758de36a4192c5c3057b5a5972b896386da5411a763aba087691edf539808616b254b84084b3340cff6e7968f9cab5004dd
   languageName: node
   linkType: hard
 
@@ -529,46 +529,46 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-syntax-export-default-from@npm:^7.24.7":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-export-default-from@npm:7.27.1"
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-export-default-from@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/9aa62f5916950f3e5f91657895f4635b1c77e108e453ef12c30dc7670c3441bdd65cd28be20d6ddc9003ed471cc98465785a14cd76c61f077c1c84264f1f28ca
+  checksum: 10c0/7d01ef992ab7e1c8a08c9e5ebacc2ff82e10592d9bc7964c9903a6766f01d371e45c25848f793393795d603d63f54dd0626b0a148df003f2a234a0a90bb31e93
   languageName: node
   linkType: hard
 
 "@babel/plugin-syntax-flow@npm:^7.12.1, @babel/plugin-syntax-flow@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-flow@npm:7.27.1"
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-flow@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/4d34ca47044398665cbe0293baea7be230ca4090bc7981ffba5273402a215c95976c6f811c7b32f10b326cc6aab6886f26c29630c429aa45c3f350c5ccdfdbbf
+  checksum: 10c0/a00114adcbbdaef07638f6a2e8c3ea63d65b3d27f088e8e53c5f35b8dc50813c0e1006fac4fb109782f9cdd41ad2f1cb9838359fecbb3d1f6141b4002358f52c
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-assertions@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-import-assertions@npm:7.27.1"
+"@babel/plugin-syntax-import-assertions@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-import-assertions@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/06a954ee672f7a7c44d52b6e55598da43a7064e80df219765c51c37a0692641277e90411028f7cae4f4d1dedeed084f0c453576fa421c35a81f1603c5e3e0146
+  checksum: 10c0/f3b8bdccb9b4d3e3b9226684ca518e055399d05579da97dfe0160a38d65198cfe7dce809e73179d6463a863a040f980de32425a876d88efe4eda933d0d95982c
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-attributes@npm:^7.24.7, @babel/plugin-syntax-import-attributes@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-import-attributes@npm:7.27.1"
+"@babel/plugin-syntax-import-attributes@npm:^7.24.7, @babel/plugin-syntax-import-attributes@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-import-attributes@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/e66f7a761b8360419bbb93ab67d87c8a97465ef4637a985ff682ce7ba6918b34b29d81190204cf908d0933058ee7b42737423cd8a999546c21b3aabad4affa9a
+  checksum: 10c0/1be160e2c426faa74e5be2e30e39e8d0d8c543063bd5d06cd804f8751b8fbcb82ce824ca7f9ce4b09c003693f6c06a11ce503b7e34d85e1a259631e4c3f72ad2
   languageName: node
   linkType: hard
 
@@ -594,14 +594,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.27.1, @babel/plugin-syntax-jsx@npm:^7.7.2":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-jsx@npm:7.27.1"
+"@babel/plugin-syntax-jsx@npm:^7.27.1, @babel/plugin-syntax-jsx@npm:^7.28.6, @babel/plugin-syntax-jsx@npm:^7.7.2":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-jsx@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/bc5afe6a458d5f0492c02a54ad98c5756a0c13bd6d20609aae65acd560a9e141b0876da5f358dce34ea136f271c1016df58b461184d7ae9c4321e0f98588bc84
+  checksum: 10c0/b98fc3cd75e4ca3d5ca1162f610c286e14ede1486e0d297c13a5eb0ac85680ac9656d17d348bddd9160a54d797a08cea5eaac02b9330ddebb7b26732b7b99fb5
   languageName: node
   linkType: hard
 
@@ -693,14 +693,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-typescript@npm:^7.27.1, @babel/plugin-syntax-typescript@npm:^7.7.2":
-  version: 7.27.1
-  resolution: "@babel/plugin-syntax-typescript@npm:7.27.1"
+"@babel/plugin-syntax-typescript@npm:^7.28.6, @babel/plugin-syntax-typescript@npm:^7.7.2":
+  version: 7.28.6
+  resolution: "@babel/plugin-syntax-typescript@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/11589b4c89c66ef02d57bf56c6246267851ec0c361f58929327dc3e070b0dab644be625bbe7fb4c4df30c3634bfdfe31244e1f517be397d2def1487dbbe3c37d
+  checksum: 10c0/b0c392a35624883ac480277401ac7d92d8646b66e33639f5d350de7a6723924265985ae11ab9ebd551740ded261c443eaa9a87ea19def9763ca1e0d78c97dea8
   languageName: node
   linkType: hard
 
@@ -727,29 +727,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-generator-functions@npm:^7.25.4, @babel/plugin-transform-async-generator-functions@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/plugin-transform-async-generator-functions@npm:7.28.0"
+"@babel/plugin-transform-async-generator-functions@npm:^7.25.4, @babel/plugin-transform-async-generator-functions@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/plugin-transform-async-generator-functions@npm:7.29.0"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-remap-async-to-generator": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.0"
+    "@babel/traverse": "npm:^7.29.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/739d577e649d7d7b9845dc309e132964327ab3eaea43ad04d04a7dcb977c63f9aa9a423d1ca39baf10939128d02f52e6fda39c834fb9f1753785b1497e72c4dc
+  checksum: 10c0/4080fc5e7dad7761bfebbb4fbe06bdfeb3a8bf0c027bcb4373e59e6b3dc7c5002eca7cbb1afba801d6439df8f92f7bcb3fb862e8fbbe43a9e59bb5653dcc0568
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-to-generator@npm:^7.24.7, @babel/plugin-transform-async-to-generator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-async-to-generator@npm:7.27.1"
+"@babel/plugin-transform-async-to-generator@npm:^7.24.7, @babel/plugin-transform-async-to-generator@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-async-to-generator@npm:7.28.6"
   dependencies:
-    "@babel/helper-module-imports": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-module-imports": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-remap-async-to-generator": "npm:^7.27.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/e76b1f6f9c3bbf72e17d7639406d47f09481806de4db99a8de375a0bb40957ea309b20aa705f0c25ab1d7c845e3f365af67eafa368034521151a0e352a03ef2f
+  checksum: 10c0/2eb0826248587df6e50038f36194a138771a7df22581020451c7779edeaf9ef39bf47c5b7a20ae2645af6416e8c896feeca273317329652e84abd79a4ab920ad
   languageName: node
   linkType: hard
 
@@ -764,70 +764,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoping@npm:^7.25.0, @babel/plugin-transform-block-scoping@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-block-scoping@npm:7.28.5"
+"@babel/plugin-transform-block-scoping@npm:^7.25.0, @babel/plugin-transform-block-scoping@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/6b098887b375c23813ccee7a00179501fc5f709b4ee5a4b2a5c5c9ef3b44cee49e240214b1a9b4ad2bd1911fab3335eac2f0a3c5f014938a1b61bec84cec4845
+  checksum: 10c0/2e3e09e1f9770b56cef4dcbffddf262508fd03416072f815ac66b2b224a3a12cd285cfec12fc067f1add414e7db5ce6dafb5164a6e0fb1a728e6a97d0c6f6e9d
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.24.7, @babel/plugin-transform-class-properties@npm:^7.25.4, @babel/plugin-transform-class-properties@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-class-properties@npm:7.27.1"
+"@babel/plugin-transform-class-properties@npm:^7.0.0-0, @babel/plugin-transform-class-properties@npm:^7.24.7, @babel/plugin-transform-class-properties@npm:^7.25.4, @babel/plugin-transform-class-properties@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-class-properties@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-class-features-plugin": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/cc0662633c0fe6df95819fef223506ddf26c369c8d64ab21a728d9007ec866bf9436a253909819216c24a82186b6ccbc1ec94d7aaf3f82df227c7c02fa6a704b
+  checksum: 10c0/c4327fcd730c239d9f173f9b695b57b801729e273b4848aef1f75818069dfd31d985d75175db188d947b9b1bbe5353dae298849042026a5e4fcf07582ff3f9f1
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-static-block@npm:^7.28.3":
-  version: 7.28.3
-  resolution: "@babel/plugin-transform-class-static-block@npm:7.28.3"
+"@babel/plugin-transform-class-static-block@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-class-static-block@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.28.3"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-class-features-plugin": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.12.0
-  checksum: 10c0/8c922a64f6f5b359f7515c89ef0037bad583b4484dfebc1f6bc1cf13462547aaceb19788827c57ec9a2d62495f34c4b471ca636bf61af00fdaea5e9642c82b60
+  checksum: 10c0/dbe9b1fd302ae41b73186e17ac8d8ecf625ebc2416a91f2dc8013977a1bdf21e6ea288a83f084752b412242f3866e789d4fddeb428af323fe35b60e0fae4f98c
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-classes@npm:^7.0.0-0, @babel/plugin-transform-classes@npm:^7.25.4, @babel/plugin-transform-classes@npm:^7.28.4":
-  version: 7.28.4
-  resolution: "@babel/plugin-transform-classes@npm:7.28.4"
+"@babel/plugin-transform-classes@npm:^7.0.0-0, @babel/plugin-transform-classes@npm:^7.25.4, @babel/plugin-transform-classes@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-classes@npm:7.28.6"
   dependencies:
     "@babel/helper-annotate-as-pure": "npm:^7.27.3"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
     "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-replace-supers": "npm:^7.27.1"
-    "@babel/traverse": "npm:^7.28.4"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/helper-replace-supers": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/76687ed37216ff012c599870dc00183fb716f22e1a02fe9481943664c0e4d0d88c3da347dc3fe290d4728f4d47cd594ffa621d23845e2bb8ab446e586308e066
+  checksum: 10c0/dc22f1f6eadab17305128fbf9cc5f30e87a51a77dd0a6d5498097994e8a9b9a90ab298c11edf2342acbeaac9edc9c601cad72eedcf4b592cd465a787d7f41490
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-computed-properties@npm:^7.24.7, @babel/plugin-transform-computed-properties@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-computed-properties@npm:7.27.1"
+"@babel/plugin-transform-computed-properties@npm:^7.24.7, @babel/plugin-transform-computed-properties@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-computed-properties@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/template": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/template": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/e09a12f8c8ae0e6a6144c102956947b4ec05f6c844169121d0ec4529c2d30ad1dc59fee67736193b87a402f44552c888a519a680a31853bdb4d34788c28af3b0
+  checksum: 10c0/1e9893503ae6d651125701cc29450e87c0b873c8febebff19da75da9c40cfb7968c52c28bf948244e461110aeb7b3591f2cc199b7406ff74a24c50c7a5729f39
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-destructuring@npm:^7.24.8, @babel/plugin-transform-destructuring@npm:^7.28.0, @babel/plugin-transform-destructuring@npm:^7.28.5":
+"@babel/plugin-transform-destructuring@npm:^7.24.8, @babel/plugin-transform-destructuring@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/plugin-transform-destructuring@npm:7.28.5"
   dependencies:
@@ -839,15 +839,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-dotall-regex@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-dotall-regex@npm:7.27.1"
+"@babel/plugin-transform-dotall-regex@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-dotall-regex@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.28.5"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/f9caddfad9a551b4dabe0dcb7c040f458fbaaa7bbb44200c20198b32c8259be8e050e58d2c853fdac901a4cfe490b86aa857036d8d461b192dd010d0e242dedb
+  checksum: 10c0/e2fb76b7ae99087cf4212013a3ca9dee07048f90f98fd6264855080fb6c3f169be11c9b8c9d8b26cf9a407e4d0a5fa6e103f7cef433a542b75cf7127c99d4f97
   languageName: node
   linkType: hard
 
@@ -862,15 +862,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-duplicate-named-capturing-groups-regex@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-duplicate-named-capturing-groups-regex@npm:7.27.1"
+"@babel/plugin-transform-duplicate-named-capturing-groups-regex@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/plugin-transform-duplicate-named-capturing-groups-regex@npm:7.29.0"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.28.5"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/121502a252b3206913e1e990a47fea34397b4cbf7804d4cd872d45961bc45b603423f60ca87f3a3023a62528f5feb475ac1c9ec76096899ec182fcb135eba375
+  checksum: 10c0/6f03d9e5e31a05b28555541be6e283407e08447a36be6ddf8068b3efa970411d832e04b1282e2b894baf89a3864ff7e7f1e36346652a8d983170c6d548555167
   languageName: node
   linkType: hard
 
@@ -885,26 +885,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-explicit-resource-management@npm:^7.28.0":
-  version: 7.28.0
-  resolution: "@babel/plugin-transform-explicit-resource-management@npm:7.28.0"
+"@babel/plugin-transform-explicit-resource-management@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-explicit-resource-management@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/plugin-transform-destructuring": "npm:^7.28.0"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/plugin-transform-destructuring": "npm:^7.28.5"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/3baa706af3112adf2ae0c7ec0dc61b63dd02695eb5582f3c3a2b2d05399c6aa7756f55e7bbbd5412e613a6ba1dd6b6736904074b4d7ebd6b45a1e3f9145e4094
+  checksum: 10c0/e6ea28c26e058fe61ada3e70b0def1992dd5a44f5fc14d8e2c6a3a512fb4d4c6dc96a3e1d0b466d83db32a9101e0b02df94051e48d3140da115b8ea9f8a31f37
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-exponentiation-operator@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.28.5"
+"@babel/plugin-transform-exponentiation-operator@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/006566e003c2a8175346cc4b3260fcd9f719b912ceae8a4e930ce02ee3cf0b2841d5c21795ba71790871783d3c0c1c3d22ce441b8819c37975844bfba027d3f7
+  checksum: 10c0/4572d955a50dbc9a652a19431b4bb822cb479ee6045f4e6df72659c499c13036da0a2adf650b07ca995f2781e80aa868943bea1e7bff1de3169ec3f0a73a902e
   languageName: node
   linkType: hard
 
@@ -956,14 +956,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-json-strings@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-json-strings@npm:7.27.1"
+"@babel/plugin-transform-json-strings@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-json-strings@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/2379714aca025516452a7c1afa1ca42a22b9b51a5050a653cc6198a51665ab82bdecf36106d32d731512706a1e373c5637f5ff635737319aa42f3827da2326d6
+  checksum: 10c0/ab1091798c58e6c0bb8a864ee2b727c400924592c6ed69797a26b4c205f850a935de77ad516570be0419c279a3d9f7740c2aa448762eb8364ea77a6a357a9653
   languageName: node
   linkType: hard
 
@@ -978,14 +978,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7, @babel/plugin-transform-logical-assignment-operators@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.28.5"
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.24.7, @babel/plugin-transform-logical-assignment-operators@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/fba4faa96d86fa745b0539bb631deee3f2296f0643c087a50ad0fac2e5f0a787fa885e9bdd90ae3e7832803f3c08e7cd3f1e830e7079dbdc023704923589bb23
+  checksum: 10c0/4632a35453d2131f0be466681d0a33e3db44d868ff51ec46cd87e0ebd1e47c6a39b894f7d1c9b06f931addf6efa9d30e60c4cdedeb4f69d426f683e11f8490cf
   languageName: node
   linkType: hard
 
@@ -1012,29 +1012,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.24.7, @babel/plugin-transform-modules-commonjs@npm:^7.24.8, @babel/plugin-transform-modules-commonjs@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.27.1"
+"@babel/plugin-transform-modules-commonjs@npm:^7.24.7, @babel/plugin-transform-modules-commonjs@npm:^7.24.8, @babel/plugin-transform-modules-commonjs@npm:^7.27.1, @babel/plugin-transform-modules-commonjs@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.28.6"
   dependencies:
-    "@babel/helper-module-transforms": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-module-transforms": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/4def972dcd23375a266ea1189115a4ff61744b2c9366fc1de648b3fab2c650faf1a94092de93a33ff18858d2e6c4dddeeee5384cb42ba0129baeab01a5cdf1e2
+  checksum: 10c0/7c45992797c6150644c8552feff4a016ba7bd6d59ff2b039ed969a9c5b20a6804cd9d21db5045fc8cca8ca7f08262497e354e93f8f2be6a1cdf3fbfa8c31a9b6
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.28.5"
+"@babel/plugin-transform-modules-systemjs@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.0"
   dependencies:
-    "@babel/helper-module-transforms": "npm:^7.28.3"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-module-transforms": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@babel/traverse": "npm:^7.28.5"
+    "@babel/traverse": "npm:^7.29.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/7e8c0bcff79689702b974f6a0fedb5d0c6eeb5a5e3384deb7028e7cfe92a5242cc80e981e9c1817aad29f2ecc01841753365dd38d877aa0b91737ceec2acfd07
+  checksum: 10c0/44ea502f2c990398b7d9adc5b44d9e1810a0a5e86eebc05c92d039458f0b3994fe243efa9353b90f8a648d8a91b79845fb353d8679d7324cc9de0162d732771d
   languageName: node
   linkType: hard
 
@@ -1050,15 +1050,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.24.7, @babel/plugin-transform-named-capturing-groups-regex@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.27.1"
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.24.7, @babel/plugin-transform-named-capturing-groups-regex@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.29.0"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.28.5"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/8eaa8c9aee00a00f3bd8bd8b561d3f569644d98cb2cfe3026d7398aabf9b29afd62f24f142b4112fa1f572d9b0e1928291b099cde59f56d6b59f4d565e58abf2
+  checksum: 10c0/1904db22da7f2bc3e380cd2c0786bda330ee1b1b3efa3f5203d980708c4bfeb5daa4dff48d01692193040bcc5f275dbdc0c2eadc8b1eb1b6dfe363564ad6e898
   languageName: node
   linkType: hard
 
@@ -1073,40 +1073,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.27.1"
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.0.0-0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.24.7, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/a435fc03aaa65c6ef8e99b2d61af0994eb5cdd4a28562d78c3b0b0228ca7e501aa255e1dff091a6996d7d3ea808eb5a65fd50ecd28dfb10687a8a1095dcadc7a
+  checksum: 10c0/6607f2201d66ccb688f0b1db09475ef995837df19f14705da41f693b669f834c206147a854864ab107913d7b4f4748878b0cd9fe9ca8bfd1bee0c206fc027b49
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.24.7, @babel/plugin-transform-numeric-separator@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-numeric-separator@npm:7.27.1"
+"@babel/plugin-transform-numeric-separator@npm:^7.24.7, @babel/plugin-transform-numeric-separator@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-numeric-separator@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/b72cbebbfe46fcf319504edc1cf59f3f41c992dd6840db766367f6a1d232cd2c52143c5eaf57e0316710bee251cae94be97c6d646b5022fcd9274ccb131b470c
+  checksum: 10c0/191097d8d2753cdd16d1acca65a945d1645ab20b65655c2f5b030a9e38967a52e093dcb21ebf391e342222705c6ffe5dea15dafd6257f7b51b77fb64a830b637
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-object-rest-spread@npm:^7.24.7, @babel/plugin-transform-object-rest-spread@npm:^7.28.4":
-  version: 7.28.4
-  resolution: "@babel/plugin-transform-object-rest-spread@npm:7.28.4"
+"@babel/plugin-transform-object-rest-spread@npm:^7.24.7, @babel/plugin-transform-object-rest-spread@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-object-rest-spread@npm:7.28.6"
   dependencies:
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/plugin-transform-destructuring": "npm:^7.28.0"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/plugin-transform-destructuring": "npm:^7.28.5"
     "@babel/plugin-transform-parameters": "npm:^7.27.7"
-    "@babel/traverse": "npm:^7.28.4"
+    "@babel/traverse": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/81725c8d6349957899975f3f789b1d4fb050ee8b04468ebfaccd5b59e0bda15cbfdef09aee8b4359f322b6715149d680361f11c1a420c4bdbac095537ecf7a90
+  checksum: 10c0/f55334352d4fcde385f2e8a58836687e71ff668c9b6e4c34d52575bf2789cdde92d9d3116edba13647ac0bc3e51fb2a6d1e8fb822dce7e8123334b82600bc4c3
   languageName: node
   linkType: hard
 
@@ -1122,26 +1122,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.24.7, @babel/plugin-transform-optional-catch-binding@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.27.1"
+"@babel/plugin-transform-optional-catch-binding@npm:^7.24.7, @babel/plugin-transform-optional-catch-binding@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/807a4330f1fac08e2682d57bc82e714868fc651c8876f9a8b3a3fd8f53c129e87371f8243e712ac7dae11e090b737a2219a02fe1b6459a29e664fa073c3277bb
+  checksum: 10c0/36e8face000ee65e478a55febf687ce9be7513ad498c60dfe585851555565e0c28e7cb891b3c59709318539ce46f7697d5f42130eb18f385cd47e47cfa297446
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.24.7, @babel/plugin-transform-optional-chaining@npm:^7.24.8, @babel/plugin-transform-optional-chaining@npm:^7.27.1, @babel/plugin-transform-optional-chaining@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-optional-chaining@npm:7.28.5"
+"@babel/plugin-transform-optional-chaining@npm:^7.0.0-0, @babel/plugin-transform-optional-chaining@npm:^7.24.7, @babel/plugin-transform-optional-chaining@npm:^7.24.8, @babel/plugin-transform-optional-chaining@npm:^7.27.1, @babel/plugin-transform-optional-chaining@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-optional-chaining@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/adf5f70b1f9eb0dd6ff3d159a714683af3c910775653e667bd9f864c3dc2dc9872aba95f6c1e5f2a9675067241942f4fd0d641147ef4bf2bd8bc15f1fa0f2ed5
+  checksum: 10c0/c159cc74115c2266be21791f192dd079e2aeb65c8731157e53b80fcefa41e8e28ad370021d4dfbdb31f25e5afa0322669a8eb2d032cd96e65ac37e020324c763
   languageName: node
   linkType: hard
 
@@ -1156,28 +1156,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.24.7, @babel/plugin-transform-private-methods@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-private-methods@npm:7.27.1"
+"@babel/plugin-transform-private-methods@npm:^7.24.7, @babel/plugin-transform-private-methods@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-private-methods@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-class-features-plugin": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/232bedfe9d28df215fb03cc7623bdde468b1246bdd6dc24465ff4bf9cc5f5a256ae33daea1fafa6cc59705e4d29da9024bb79baccaa5cd92811ac5db9b9244f2
+  checksum: 10c0/fb504e2bfdcf3f734d2a90ab20d61427c58385f57f950d3de6ff4e6d12dd4aa7d552147312d218367e129b7920dccfc3230ba554de861986cda38921bad84067
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-property-in-object@npm:^7.24.7, @babel/plugin-transform-private-property-in-object@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-private-property-in-object@npm:7.27.1"
+"@babel/plugin-transform-private-property-in-object@npm:^7.24.7, @babel/plugin-transform-private-property-in-object@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-private-property-in-object@npm:7.28.6"
   dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.27.1"
-    "@babel/helper-create-class-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-annotate-as-pure": "npm:^7.27.3"
+    "@babel/helper-create-class-features-plugin": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/a8c4536273ca716dcc98e74ea25ca76431528554922f184392be3ddaf1761d4aa0e06f1311577755bd1613f7054fb51d29de2ada1130f743d329170a1aa1fe56
+  checksum: 10c0/0f6bbc6ec3f93b556d3de7d56bf49335255fc4c43488e51a5025d6ee0286183fd3cf950ffcac1bbeed8a45777f860a49996455c8d3b4a04c3b1a5f28e697fe31
   languageName: node
   linkType: hard
 
@@ -1237,17 +1237,17 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-react-jsx@npm:^7.25.2, @babel/plugin-transform-react-jsx@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx@npm:7.27.1"
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.28.6"
   dependencies:
-    "@babel/helper-annotate-as-pure": "npm:^7.27.1"
-    "@babel/helper-module-imports": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/plugin-syntax-jsx": "npm:^7.27.1"
-    "@babel/types": "npm:^7.27.1"
+    "@babel/helper-annotate-as-pure": "npm:^7.27.3"
+    "@babel/helper-module-imports": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/plugin-syntax-jsx": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/1a08637c39fc78c9760dd4a3ed363fdbc762994bf83ed7872ad5bda0232fcd0fc557332f2ce36b522c0226dfd9cc8faac6b88eddda535f24825198a689e571af
+  checksum: 10c0/cc75b9bb3997751df6cf7e86afe1b3fa33130b5031a412f6f12cc5faec083650fe852de0af5ec8f88d3588cc3428a3f514d3bc1f423d26f8b014cc5dff9f15a7
   languageName: node
   linkType: hard
 
@@ -1263,26 +1263,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-regenerator@npm:^7.24.7, @babel/plugin-transform-regenerator@npm:^7.28.4":
-  version: 7.28.4
-  resolution: "@babel/plugin-transform-regenerator@npm:7.28.4"
+"@babel/plugin-transform-regenerator@npm:^7.24.7, @babel/plugin-transform-regenerator@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/plugin-transform-regenerator@npm:7.29.0"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/5ad14647ffaac63c920e28df1b580ee2e932586bbdc71f61ec264398f68a5406c71a7f921de397a41b954a69316c5ab90e5d789ffa2bb34c5e6feb3727cfefb8
+  checksum: 10c0/86c7db9b97f85ee47c0fae0528802cbc06e5775e61580ee905335c16bb971270086764a3859873d9adcd7d0f913a5b93eb0dc271aec8fb9e93e090e4ac95e29e
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-regexp-modifiers@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-regexp-modifiers@npm:7.27.1"
+"@babel/plugin-transform-regexp-modifiers@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-regexp-modifiers@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.28.5"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/31ae596ab56751cf43468a6c0a9d6bc3521d306d2bee9c6957cdb64bea53812ce24bd13a32f766150d62b737bca5b0650b2c62db379382fff0dccbf076055c33
+  checksum: 10c0/97e36b086800f71694fa406abc00192e3833662f2bdd5f51c018bd0c95eef247c4ae187417c207d03a9c5374342eac0bb65a39112c431a9b23b09b1eda1562e5
   languageName: node
   linkType: hard
 
@@ -1298,18 +1298,18 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-runtime@npm:^7.24.7":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-runtime@npm:7.28.5"
+  version: 7.29.0
+  resolution: "@babel/plugin-transform-runtime@npm:7.29.0"
   dependencies:
-    "@babel/helper-module-imports": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-module-imports": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     babel-plugin-polyfill-corejs2: "npm:^0.4.14"
     babel-plugin-polyfill-corejs3: "npm:^0.13.0"
     babel-plugin-polyfill-regenerator: "npm:^0.6.5"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/d20901d179a7044327dec7b37dd4fadbc4c1c0dc1cb6a3dd69e67166b43b06c262dd0f2e70aedf1c0dab42044c0c063468d99019ae1c9290312b6b8802c502f9
+  checksum: 10c0/05a451cb96a1e6ccfdd1a123773208615cd14cb156aa0aa99a448d86e4326b36b9ab2be8267037bd27644a5918dac88378b791d020b3c08a4fd8f3415621a006
   languageName: node
   linkType: hard
 
@@ -1324,15 +1324,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-spread@npm:^7.24.7, @babel/plugin-transform-spread@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-spread@npm:7.27.1"
+"@babel/plugin-transform-spread@npm:^7.24.7, @babel/plugin-transform-spread@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-spread@npm:7.28.6"
   dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/b34fc58b33bd35b47d67416655c2cbc8578fbb3948b4592bc15eb6d8b4046986e25c06e3b9929460fa4ab08e9653582415e7ef8b87d265e1239251bdf5a4c162
+  checksum: 10c0/bcac50e558d6f0c501cbce19ec197af558cef51fe3b3a6eba27276e323e57a5be28109b4264a5425ac12a67bf95d6af9c2a42b05e79c522ce913fb9529259d76
   languageName: node
   linkType: hard
 
@@ -1381,17 +1381,17 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-typescript@npm:^7.25.2, @babel/plugin-transform-typescript@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-typescript@npm:7.28.5"
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-typescript@npm:7.28.6"
   dependencies:
     "@babel/helper-annotate-as-pure": "npm:^7.27.3"
-    "@babel/helper-create-class-features-plugin": "npm:^7.28.5"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-class-features-plugin": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
-    "@babel/plugin-syntax-typescript": "npm:^7.27.1"
+    "@babel/plugin-syntax-typescript": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/09e574ba5462e56452b4ceecae65e53c8e697a2d3559ce5d210bed10ac28a18aa69377e7550c30520eb29b40c417ee61997d5d58112657f22983244b78915a7c
+  checksum: 10c0/72dbfd3e5f71c4e30445e610758ec0eef65347fafd72bd46f4903733df0d537663a72a81c1626f213a0feab7afc68ba83f1648ffece888dd0868115c9cb748f6
   languageName: node
   linkType: hard
 
@@ -1406,15 +1406,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-property-regex@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-unicode-property-regex@npm:7.27.1"
+"@babel/plugin-transform-unicode-property-regex@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-unicode-property-regex@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.28.5"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/a332bc3cb3eeea67c47502bc52d13a0f8abae5a7bfcb08b93a8300ddaff8d9e1238f912969494c1b494c1898c6f19687054440706700b6d12cb0b90d88beb4d0
+  checksum: 10c0/b25f8cde643f4f47e0fa4f7b5c552e2dfbb6ad0ce07cf40f7e8ae40daa9855ad855d76d4d6d010153b74e48c8794685955c92ca637c0da152ce5f0fa9e7c90fa
   languageName: node
   linkType: hard
 
@@ -1430,95 +1430,95 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-sets-regex@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-unicode-sets-regex@npm:7.27.1"
+"@babel/plugin-transform-unicode-sets-regex@npm:^7.28.6":
+  version: 7.28.6
+  resolution: "@babel/plugin-transform-unicode-sets-regex@npm:7.28.6"
   dependencies:
-    "@babel/helper-create-regexp-features-plugin": "npm:^7.27.1"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.28.5"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/236645f4d0a1fba7c18dc8ffe3975933af93e478f2665650c2d91cf528cfa1587cde5cfe277e0e501fc03b5bf57638369575d6539cef478632fb93bd7d7d7178
+  checksum: 10c0/c03c8818736b138db73d1f7a96fbfa22d1994639164d743f0f00e6383d3b7b3144d333de960ff4afad0bddd0baaac257295e3316969eba995b1b6a1b4dec933e
   languageName: node
   linkType: hard
 
 "@babel/preset-env@npm:^7.25.2":
-  version: 7.28.5
-  resolution: "@babel/preset-env@npm:7.28.5"
+  version: 7.29.2
+  resolution: "@babel/preset-env@npm:7.29.2"
   dependencies:
-    "@babel/compat-data": "npm:^7.28.5"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
+    "@babel/compat-data": "npm:^7.29.0"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-validator-option": "npm:^7.27.1"
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.28.5"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope": "npm:^7.27.1"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.27.1"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.27.1"
-    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "npm:^7.28.3"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "npm:^7.28.6"
     "@babel/plugin-proposal-private-property-in-object": "npm:7.21.0-placeholder-for-preset-env.2"
-    "@babel/plugin-syntax-import-assertions": "npm:^7.27.1"
-    "@babel/plugin-syntax-import-attributes": "npm:^7.27.1"
+    "@babel/plugin-syntax-import-assertions": "npm:^7.28.6"
+    "@babel/plugin-syntax-import-attributes": "npm:^7.28.6"
     "@babel/plugin-syntax-unicode-sets-regex": "npm:^7.18.6"
     "@babel/plugin-transform-arrow-functions": "npm:^7.27.1"
-    "@babel/plugin-transform-async-generator-functions": "npm:^7.28.0"
-    "@babel/plugin-transform-async-to-generator": "npm:^7.27.1"
+    "@babel/plugin-transform-async-generator-functions": "npm:^7.29.0"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.28.6"
     "@babel/plugin-transform-block-scoped-functions": "npm:^7.27.1"
-    "@babel/plugin-transform-block-scoping": "npm:^7.28.5"
-    "@babel/plugin-transform-class-properties": "npm:^7.27.1"
-    "@babel/plugin-transform-class-static-block": "npm:^7.28.3"
-    "@babel/plugin-transform-classes": "npm:^7.28.4"
-    "@babel/plugin-transform-computed-properties": "npm:^7.27.1"
+    "@babel/plugin-transform-block-scoping": "npm:^7.28.6"
+    "@babel/plugin-transform-class-properties": "npm:^7.28.6"
+    "@babel/plugin-transform-class-static-block": "npm:^7.28.6"
+    "@babel/plugin-transform-classes": "npm:^7.28.6"
+    "@babel/plugin-transform-computed-properties": "npm:^7.28.6"
     "@babel/plugin-transform-destructuring": "npm:^7.28.5"
-    "@babel/plugin-transform-dotall-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.28.6"
     "@babel/plugin-transform-duplicate-keys": "npm:^7.27.1"
-    "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "npm:^7.29.0"
     "@babel/plugin-transform-dynamic-import": "npm:^7.27.1"
-    "@babel/plugin-transform-explicit-resource-management": "npm:^7.28.0"
-    "@babel/plugin-transform-exponentiation-operator": "npm:^7.28.5"
+    "@babel/plugin-transform-explicit-resource-management": "npm:^7.28.6"
+    "@babel/plugin-transform-exponentiation-operator": "npm:^7.28.6"
     "@babel/plugin-transform-export-namespace-from": "npm:^7.27.1"
     "@babel/plugin-transform-for-of": "npm:^7.27.1"
     "@babel/plugin-transform-function-name": "npm:^7.27.1"
-    "@babel/plugin-transform-json-strings": "npm:^7.27.1"
+    "@babel/plugin-transform-json-strings": "npm:^7.28.6"
     "@babel/plugin-transform-literals": "npm:^7.27.1"
-    "@babel/plugin-transform-logical-assignment-operators": "npm:^7.28.5"
+    "@babel/plugin-transform-logical-assignment-operators": "npm:^7.28.6"
     "@babel/plugin-transform-member-expression-literals": "npm:^7.27.1"
     "@babel/plugin-transform-modules-amd": "npm:^7.27.1"
-    "@babel/plugin-transform-modules-commonjs": "npm:^7.27.1"
-    "@babel/plugin-transform-modules-systemjs": "npm:^7.28.5"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.28.6"
+    "@babel/plugin-transform-modules-systemjs": "npm:^7.29.0"
     "@babel/plugin-transform-modules-umd": "npm:^7.27.1"
-    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.29.0"
     "@babel/plugin-transform-new-target": "npm:^7.27.1"
-    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.27.1"
-    "@babel/plugin-transform-numeric-separator": "npm:^7.27.1"
-    "@babel/plugin-transform-object-rest-spread": "npm:^7.28.4"
+    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.28.6"
+    "@babel/plugin-transform-numeric-separator": "npm:^7.28.6"
+    "@babel/plugin-transform-object-rest-spread": "npm:^7.28.6"
     "@babel/plugin-transform-object-super": "npm:^7.27.1"
-    "@babel/plugin-transform-optional-catch-binding": "npm:^7.27.1"
-    "@babel/plugin-transform-optional-chaining": "npm:^7.28.5"
+    "@babel/plugin-transform-optional-catch-binding": "npm:^7.28.6"
+    "@babel/plugin-transform-optional-chaining": "npm:^7.28.6"
     "@babel/plugin-transform-parameters": "npm:^7.27.7"
-    "@babel/plugin-transform-private-methods": "npm:^7.27.1"
-    "@babel/plugin-transform-private-property-in-object": "npm:^7.27.1"
+    "@babel/plugin-transform-private-methods": "npm:^7.28.6"
+    "@babel/plugin-transform-private-property-in-object": "npm:^7.28.6"
     "@babel/plugin-transform-property-literals": "npm:^7.27.1"
-    "@babel/plugin-transform-regenerator": "npm:^7.28.4"
-    "@babel/plugin-transform-regexp-modifiers": "npm:^7.27.1"
+    "@babel/plugin-transform-regenerator": "npm:^7.29.0"
+    "@babel/plugin-transform-regexp-modifiers": "npm:^7.28.6"
     "@babel/plugin-transform-reserved-words": "npm:^7.27.1"
     "@babel/plugin-transform-shorthand-properties": "npm:^7.27.1"
-    "@babel/plugin-transform-spread": "npm:^7.27.1"
+    "@babel/plugin-transform-spread": "npm:^7.28.6"
     "@babel/plugin-transform-sticky-regex": "npm:^7.27.1"
     "@babel/plugin-transform-template-literals": "npm:^7.27.1"
     "@babel/plugin-transform-typeof-symbol": "npm:^7.27.1"
     "@babel/plugin-transform-unicode-escapes": "npm:^7.27.1"
-    "@babel/plugin-transform-unicode-property-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-unicode-property-regex": "npm:^7.28.6"
     "@babel/plugin-transform-unicode-regex": "npm:^7.27.1"
-    "@babel/plugin-transform-unicode-sets-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-unicode-sets-regex": "npm:^7.28.6"
     "@babel/preset-modules": "npm:0.1.6-no-external-plugins"
-    babel-plugin-polyfill-corejs2: "npm:^0.4.14"
-    babel-plugin-polyfill-corejs3: "npm:^0.13.0"
-    babel-plugin-polyfill-regenerator: "npm:^0.6.5"
-    core-js-compat: "npm:^3.43.0"
+    babel-plugin-polyfill-corejs2: "npm:^0.4.15"
+    babel-plugin-polyfill-corejs3: "npm:^0.14.0"
+    babel-plugin-polyfill-regenerator: "npm:^0.6.6"
+    core-js-compat: "npm:^3.48.0"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/d1b730158de290f1c54ed7db0f4fed3f82db5f868ab0a4cb3fc2ea76ed683b986ae136f6e7eb0b44b91bc9a99039a2559851656b4fd50193af1a815a3e32e524
+  checksum: 10c0/d49cb005f2dbc3f2293ab6d80ee8f1380e6215af5518fe26b087c8961c1ea8ebaa554dfce589abe1fbebac25ad7c2515d943dec3859ea2d4981a3f8f4711c580
   languageName: node
   linkType: hard
 
@@ -1580,8 +1580,8 @@ __metadata:
   linkType: hard
 
 "@babel/register@npm:^7.24.6":
-  version: 7.28.3
-  resolution: "@babel/register@npm:7.28.3"
+  version: 7.28.6
+  resolution: "@babel/register@npm:7.28.6"
   dependencies:
     clone-deep: "npm:^4.0.1"
     find-cache-dir: "npm:^2.0.0"
@@ -1590,50 +1590,50 @@ __metadata:
     source-map-support: "npm:^0.5.16"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10c0/ff31870a24e862fca36d5c481eda40be610af215a922560834333a78000b0e159a209dae606d4d93d7456d35ea8caeaaea674cdeaa0c0362e7e30d7f095d2436
+  checksum: 10c0/372380504970cf7654c2d65e09c34ed0b3217da64cb0edb6376a89eba7b603c8bdaba666eead7dcd6ed21badd52d396c2c0d6f914ae4dc6c9009e3d03d260e98
   languageName: node
   linkType: hard
 
 "@babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.27.6":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10c0/30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.25.0, @babel/template@npm:^7.27.1, @babel/template@npm:^7.27.2, @babel/template@npm:^7.3.3":
-  version: 7.27.2
-  resolution: "@babel/template@npm:7.27.2"
+"@babel/template@npm:^7.25.0, @babel/template@npm:^7.28.6, @babel/template@npm:^7.3.3":
+  version: 7.28.6
+  resolution: "@babel/template@npm:7.28.6"
   dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/parser": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.1"
-  checksum: 10c0/ed9e9022651e463cc5f2cc21942f0e74544f1754d231add6348ff1b472985a3b3502041c0be62dc99ed2d12cfae0c51394bf827452b98a2f8769c03b87aadc81
+    "@babel/code-frame": "npm:^7.28.6"
+    "@babel/parser": "npm:^7.28.6"
+    "@babel/types": "npm:^7.28.6"
+  checksum: 10c0/66d87225ed0bc77f888181ae2d97845021838c619944877f7c4398c6748bcf611f216dfd6be74d39016af502bca876e6ce6873db3c49e4ac354c56d34d57e9f5
   languageName: node
   linkType: hard
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3, @babel/traverse@npm:^7.25.3, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.0, @babel/traverse@npm:^7.28.3, @babel/traverse@npm:^7.28.4, @babel/traverse@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/traverse@npm:7.28.5"
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3, @babel/traverse@npm:^7.25.3, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.5, @babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/traverse@npm:7.29.0"
   dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.5"
+    "@babel/code-frame": "npm:^7.29.0"
+    "@babel/generator": "npm:^7.29.0"
     "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.5"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/types": "npm:^7.29.0"
     debug: "npm:^4.3.1"
-  checksum: 10c0/f6c4a595993ae2b73f2d4cd9c062f2e232174d293edd4abe1d715bd6281da8d99e47c65857e8d0917d9384c65972f4acdebc6749a7c40a8fcc38b3c7fb3e706f
+  checksum: 10c0/f63ef6e58d02a9fbf3c0e2e5f1c877da3e0bc57f91a19d2223d53e356a76859cbaf51171c9211c71816d94a0e69efa2732fd27ffc0e1bbc84b636e60932333eb
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.2, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.28.5, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
-  version: 7.28.5
-  resolution: "@babel/types@npm:7.28.5"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.25.2, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+  version: 7.29.0
+  resolution: "@babel/types@npm:7.29.0"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10c0/a5a483d2100befbf125793640dec26b90b95fd233a94c19573325898a5ce1e52cdfa96e495c7dcc31b5eca5b66ce3e6d4a0f5a4a62daec271455959f208ab08a
+  checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
   languageName: node
   linkType: hard
 
@@ -1842,22 +1842,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@conventional-changelog/git-client@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@conventional-changelog/git-client@npm:2.5.1"
+"@conventional-changelog/git-client@npm:^2.5.1, @conventional-changelog/git-client@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@conventional-changelog/git-client@npm:2.6.0"
   dependencies:
     "@simple-libs/child-process-utils": "npm:^1.0.0"
-    "@simple-libs/stream-utils": "npm:^1.1.0"
+    "@simple-libs/stream-utils": "npm:^1.2.0"
     semver: "npm:^7.5.2"
   peerDependencies:
     conventional-commits-filter: ^5.0.0
-    conventional-commits-parser: ^6.1.0
+    conventional-commits-parser: ^6.3.0
   peerDependenciesMeta:
     conventional-commits-filter:
       optional: true
     conventional-commits-parser:
       optional: true
-  checksum: 10c0/a36fd997933afe78097e53b13ffadd6c17087265666c7faf223126b39e856c39167f245a0c2151c0f0b622e0bcd4d9bf0877316a00362d7a4f4d0304c92f8d65
+  checksum: 10c0/7f0582858c5a2ecd481e9c3cfd4d87aeecc2ae5894b968a58b692e2a085b80345f069ba33274c77292b64e29af07a98531accb46d7902e93b7c6dce11aee1eb1
   languageName: node
   linkType: hard
 
@@ -1871,13 +1871,13 @@ __metadata:
   linkType: hard
 
 "@eslint-community/eslint-utils@npm:^4.2.0":
-  version: 4.9.0
-  resolution: "@eslint-community/eslint-utils@npm:4.9.0"
+  version: 4.9.1
+  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/8881e22d519326e7dba85ea915ac7a143367c805e6ba1374c987aa2fbdd09195cc51183d2da72c0e2ff388f84363e1b220fd0d19bef10c272c63455162176817
+  checksum: 10c0/dc4ab5e3e364ef27e33666b11f4b86e1a6c1d7cbf16f0c6ff87b1619b3562335e9201a3d6ce806221887ff780ec9d828962a290bb910759fd40a674686503f02
   languageName: node
   linkType: hard
 
@@ -2032,7 +2032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/config@npm:~11.0.12, @expo/config@npm:~11.0.13":
+"@expo/config@npm:~11.0.13":
   version: 11.0.13
   resolution: "@expo/config@npm:11.0.13"
   dependencies:
@@ -2054,13 +2054,12 @@ __metadata:
   linkType: hard
 
 "@expo/devcert@npm:^1.1.2":
-  version: 1.2.0
-  resolution: "@expo/devcert@npm:1.2.0"
+  version: 1.2.1
+  resolution: "@expo/devcert@npm:1.2.1"
   dependencies:
     "@expo/sudo-prompt": "npm:^9.3.1"
     debug: "npm:^3.1.0"
-    glob: "npm:^10.4.2"
-  checksum: 10c0/3d6a1ce44918c2e5be3bb89d25cfc80551623e4fe5004d4eb29d1edc8edd676258345e64d2aefe56188bc5d4b33e2b7e733a108b2be225af1f90ca86d7170069
+  checksum: 10c0/7c5cb4fa74a14702a44b4772a56f27fd191b6cd08988f3da01323f6d592623c80247171b7d66b2c0a32408f48a0814162dbb2764042444887f27e38b89ad1051
   languageName: node
   linkType: hard
 
@@ -2116,13 +2115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/json-file@npm:^10.0.7":
-  version: 10.0.7
-  resolution: "@expo/json-file@npm:10.0.7"
+"@expo/json-file@npm:^10.0.12":
+  version: 10.0.12
+  resolution: "@expo/json-file@npm:10.0.12"
   dependencies:
-    "@babel/code-frame": "npm:~7.10.4"
+    "@babel/code-frame": "npm:^7.20.0"
     json5: "npm:^2.2.3"
-  checksum: 10c0/3dfff7fe435d286f6c2f55569a8667f6d52133fc96a263e7421fa49cbf2ad7a4e2952da1fa7a3cdb15c52f11e891335ec784d358c3be554f966fdf5c836cc944
+  checksum: 10c0/52131a6426e96208ff1b295d580fc70eebb8e292b29fde1db016b2f21a0942a7521feec96b3f58efe5b32dcc1642d569b4211d651146fcdb9bf7e5f08b635878
   languageName: node
   linkType: hard
 
@@ -2173,26 +2172,25 @@ __metadata:
   linkType: hard
 
 "@expo/osascript@npm:^2.2.5":
-  version: 2.3.7
-  resolution: "@expo/osascript@npm:2.3.7"
+  version: 2.4.2
+  resolution: "@expo/osascript@npm:2.4.2"
   dependencies:
     "@expo/spawn-async": "npm:^1.7.2"
-    exec-async: "npm:^2.2.0"
-  checksum: 10c0/7778120019f3969e68e2473d8a75e35b03e1b8f573a6d306603b9007953595b28ef042eaf16580f00c48b063fdc808f7a8a6cfd302fedcbe149bd1a3e44c84c9
+  checksum: 10c0/80adc04b4a6f0695d00a88dcfe3336b395d6431fdccb9e8316c2ec1819ae6524a7063d7c8f4da7f1f3718e57637204c62c2383b7488b0008410efeb7108aa00f
   languageName: node
   linkType: hard
 
 "@expo/package-manager@npm:^1.8.6":
-  version: 1.9.8
-  resolution: "@expo/package-manager@npm:1.9.8"
+  version: 1.10.3
+  resolution: "@expo/package-manager@npm:1.10.3"
   dependencies:
-    "@expo/json-file": "npm:^10.0.7"
+    "@expo/json-file": "npm:^10.0.12"
     "@expo/spawn-async": "npm:^1.7.2"
     chalk: "npm:^4.0.0"
     npm-package-arg: "npm:^11.0.0"
     ora: "npm:^3.4.0"
     resolve-workspace-root: "npm:^2.0.0"
-  checksum: 10c0/d9f727a9b02a13d7fac8afccc5608f46690ca3e27f834042e74bc271607a5a085ad4600a19eeda55556251b8f1f0960cf71609680df7fedf76750141cb0d2a9e
+  checksum: 10c0/b9e6071b9f29f20ef4aae06390c207f22b17eced1fa2d77903100ab7efefe0951a8735dee997ac434550938d939d132a5b1f3f35344bfe9e40344c090d0ebedc
   languageName: node
   linkType: hard
 
@@ -2226,9 +2224,9 @@ __metadata:
   linkType: hard
 
 "@expo/schema-utils@npm:^0.1.0":
-  version: 0.1.7
-  resolution: "@expo/schema-utils@npm:0.1.7"
-  checksum: 10c0/1099bd8801ff941584bc6d2bb44613f9fb87af663843d629d9ede8315f44f7332c881b70f1681e8f8fc82b27472b4a025341963f0f347e16a0ae90fcb65138cd
+  version: 0.1.8
+  resolution: "@expo/schema-utils@npm:0.1.8"
+  checksum: 10c0/9a600ac858bcd1bd24ccac3e86cbef996c2c58cb20ce61fb1fc753f36dce4a000510e61b803ad5cb221a16caa38b54b243f08ac08e0de69e4aa556798d877f02
   languageName: node
   linkType: hard
 
@@ -2274,22 +2272,21 @@ __metadata:
   linkType: hard
 
 "@expo/xcpretty@npm:^4.3.0":
-  version: 4.3.2
-  resolution: "@expo/xcpretty@npm:4.3.2"
+  version: 4.4.1
+  resolution: "@expo/xcpretty@npm:4.4.1"
   dependencies:
-    "@babel/code-frame": "npm:7.10.4"
+    "@babel/code-frame": "npm:^7.20.0"
     chalk: "npm:^4.1.0"
-    find-up: "npm:^5.0.0"
     js-yaml: "npm:^4.1.0"
   bin:
     excpretty: build/cli.js
-  checksum: 10c0/e524817b2e42fb8c8914fca7e8f7c2f723f4f6d338a57b7ae97cd3e76da8108af63a22d4c7dc2e96a192a248a242f6e0f8056f0ca53bc4fb5cd2e5ae428e0891
+  checksum: 10c0/23bfd12b54bb296284402a4c547a73874b0ed4fa5f5dea26d5f80525c29befe40edb79df921fb3fd783cf0008779b29b7d4d606f2540cc23f96e39cbdc0b21dd
   languageName: node
   linkType: hard
 
 "@futurejj/react-native-checkbox@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@futurejj/react-native-checkbox@npm:1.0.5"
+  version: 1.0.6
+  resolution: "@futurejj/react-native-checkbox@npm:1.0.6"
   peerDependencies:
     react: "*"
     react-native: "*"
@@ -2297,7 +2294,14 @@ __metadata:
   peerDependenciesMeta:
     react-native-vector-icons:
       optional: true
-  checksum: 10c0/71b524dad79153e8608b16e5097fd91eb69518545ef7d9ac06d8497061cbe37db56bcbb745934be97c2ce9d8671b9daaa7257e7ed780d3f819b56291808b23a8
+  checksum: 10c0/e38f243f32dcceab2faed30a71642feebbabb272cf0798279ce8a8c5d9082147f979b2dfa9191fbb39a624033372cad241786cd7bdee451cea3b1a39df83edba
+  languageName: node
+  linkType: hard
+
+"@gar/promise-retry@npm:^1.0.0, @gar/promise-retry@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@gar/promise-retry@npm:1.0.3"
+  checksum: 10c0/885b02c8b0d75b2d215da25f3b639158c4fbe8fefe0d79163304534b9a6d0710db4b7699f7cd3cc1a730792bff04cbe19f4850a62d3e105a663eaeec88f38332
   languageName: node
   linkType: hard
 
@@ -2585,22 +2589,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/a846c7a570e3bf2657d489bcc5dcdc3179d24c7323719de1951dcdb722400ac76e5b2bfe9765d0a789bc1921fac810983d7999f021f30a78a6a174c23fc78dc9
-  languageName: node
-  linkType: hard
-
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@isaacs/brace-expansion@npm:5.0.1"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/e5d67c7bbf1f17b88132a35bc638af306d48acbb72810d48fa6e6edd8ab375854773108e8bf70f021f7ef6a8273455a6d1f0c3b5aa2aff06ce7894049ab77fb8
   languageName: node
   linkType: hard
 
@@ -3012,10 +3000,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/arborist@npm:^9.2.0":
-  version: 9.2.0
-  resolution: "@npmcli/arborist@npm:9.2.0"
+"@npmcli/arborist@npm:^9.4.2":
+  version: 9.4.2
+  resolution: "@npmcli/arborist@npm:9.4.2"
   dependencies:
+    "@gar/promise-retry": "npm:^1.0.0"
     "@isaacs/string-locale-compare": "npm:^1.1.0"
     "@npmcli/fs": "npm:^5.0.0"
     "@npmcli/installed-package-contents": "npm:^4.0.0"
@@ -3051,13 +3040,13 @@ __metadata:
     walk-up-path: "npm:^4.0.0"
   bin:
     arborist: bin/index.js
-  checksum: 10c0/e1b7785bc719710e5769f8db39385e5b20601c8b58a2678ce7518f6eb6ae4f30065e6f29a4021b111d28c05872efa6059262dc7a213744e318599fd11ba0a4f3
+  checksum: 10c0/490525c3e94a9a20ce330d04c708af8fff08d26189fa5b71b541f2c5ce9295034e0c20e4b3db20feb7de98d0bd42b57d81a4b40bdcbf0a45398dc420c2af9578
   languageName: node
   linkType: hard
 
-"@npmcli/config@npm:^10.6.0":
-  version: 10.6.0
-  resolution: "@npmcli/config@npm:10.6.0"
+"@npmcli/config@npm:^10.8.0":
+  version: 10.8.0
+  resolution: "@npmcli/config@npm:10.8.0"
   dependencies:
     "@npmcli/map-workspaces": "npm:^5.0.0"
     "@npmcli/package-json": "npm:^7.0.0"
@@ -3067,7 +3056,7 @@ __metadata:
     proc-log: "npm:^6.0.0"
     semver: "npm:^7.3.5"
     walk-up-path: "npm:^4.0.0"
-  checksum: 10c0/13fc1db3c8f7c74bdbbc7a9a960d671e92ca15be24388bdb1822420924e4598e0a720bd1a3d49e086ee5345fb0235f1800464251758a5bcca891a91d30e312ff
+  checksum: 10c0/86822f3a77f7730386644dd832192172fcba6ac61355a93f2cac76ccca0b1fd111d731205830a37f4fc65c8164c66d2253d422f2c8d504a4916706a4d7500a83
   languageName: node
   linkType: hard
 
@@ -3081,18 +3070,18 @@ __metadata:
   linkType: hard
 
 "@npmcli/git@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "@npmcli/git@npm:7.0.1"
+  version: 7.0.2
+  resolution: "@npmcli/git@npm:7.0.2"
   dependencies:
+    "@gar/promise-retry": "npm:^1.0.0"
     "@npmcli/promise-spawn": "npm:^9.0.0"
     ini: "npm:^6.0.0"
     lru-cache: "npm:^11.2.1"
     npm-pick-manifest: "npm:^11.0.1"
     proc-log: "npm:^6.0.0"
-    promise-retry: "npm:^2.0.1"
     semver: "npm:^7.3.5"
     which: "npm:^6.0.0"
-  checksum: 10c0/ddd71ca42387463e5bc7d1cdbff0e5991ac93d96d39e078ea81d4600dc2257d062377d350744da0931be89e94e72a57ef2e3f679beb0c1d45a65129806bbd565
+  checksum: 10c0/1936471c3188aa470d0c0dd4d49724bf144e381d122252d001475d69a96cd9de950936f55fec8c6a673a47cf607b11a662fc8b8a45c67d5c37c795b07d2be8e9
   languageName: node
   linkType: hard
 
@@ -3147,9 +3136,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/package-json@npm:^7.0.0, @npmcli/package-json@npm:^7.0.4":
-  version: 7.0.4
-  resolution: "@npmcli/package-json@npm:7.0.4"
+"@npmcli/package-json@npm:^7.0.0, @npmcli/package-json@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "@npmcli/package-json@npm:7.0.5"
   dependencies:
     "@npmcli/git": "npm:^7.0.0"
     glob: "npm:^13.0.0"
@@ -3157,8 +3146,8 @@ __metadata:
     json-parse-even-better-errors: "npm:^5.0.0"
     proc-log: "npm:^6.0.0"
     semver: "npm:^7.5.3"
-    validate-npm-package-license: "npm:^3.0.4"
-  checksum: 10c0/6643e62ea2c0289053cb7741edc26764a84698ddacf9d0b77ded250f02c04a560062eb1be6180afe30c2764978435c7120054e920128ab774bee48f0500a0c1d
+    spdx-expression-parse: "npm:^4.0.0"
+  checksum: 10c0/4a04af494cd7273d4a5e930f53f30217dad389c7eaeb4de667aca84be27e668ebd8b16a6923ce58dc3090030f9126885b4cfc790517050acf179d0d9e0ca6de1
   languageName: node
   linkType: hard
 
@@ -3187,17 +3176,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/run-script@npm:^10.0.0, @npmcli/run-script@npm:^10.0.3":
-  version: 10.0.3
-  resolution: "@npmcli/run-script@npm:10.0.3"
+"@npmcli/run-script@npm:^10.0.0, @npmcli/run-script@npm:^10.0.4":
+  version: 10.0.4
+  resolution: "@npmcli/run-script@npm:10.0.4"
   dependencies:
     "@npmcli/node-gyp": "npm:^5.0.0"
     "@npmcli/package-json": "npm:^7.0.0"
     "@npmcli/promise-spawn": "npm:^9.0.0"
     node-gyp: "npm:^12.1.0"
     proc-log: "npm:^6.0.0"
-    which: "npm:^6.0.0"
-  checksum: 10c0/227483417d1f36011d35d1b868cd7a9c615553f195a86a282ca3c273e89f38f172fc1fcbb8f1635d419c861679570887874a37f9f21350e0b6fc813930224358
+  checksum: 10c0/4d65682491ce7462c6a16a3d20511f70074a0ab384e4e08786ff6c2df9630ad29caa564b5ace49ec3ba5a7f483dfbd13168da903c433a48e59c73189306b1a2f
   languageName: node
   linkType: hard
 
@@ -3223,13 +3211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/endpoint@npm:^11.0.2":
-  version: 11.0.2
-  resolution: "@octokit/endpoint@npm:11.0.2"
+"@octokit/endpoint@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "@octokit/endpoint@npm:11.0.3"
   dependencies:
     "@octokit/types": "npm:^16.0.0"
     universal-user-agent: "npm:^7.0.2"
-  checksum: 10c0/878ac12fbccff772968689b4744590677c5a3f12bebe31544832c84761bf1c6be521e8a3af07abffc9455a74dd4d1f350d714fc46fd7ce14a0a2b5f2d4e3a84c
+  checksum: 10c0/3f9b67e6923ece5009aebb0dcbae5837fb574bc422561424049a43ead7fea6f132234edb72239d6ec067cf734937a608e4081af81c109de2cb754528f0d00520
   languageName: node
   linkType: hard
 
@@ -3283,15 +3271,15 @@ __metadata:
   linkType: hard
 
 "@octokit/plugin-retry@npm:^8.0.0":
-  version: 8.0.3
-  resolution: "@octokit/plugin-retry@npm:8.0.3"
+  version: 8.1.0
+  resolution: "@octokit/plugin-retry@npm:8.1.0"
   dependencies:
     "@octokit/request-error": "npm:^7.0.2"
     "@octokit/types": "npm:^16.0.0"
     bottleneck: "npm:^2.15.3"
   peerDependencies:
     "@octokit/core": ">=7"
-  checksum: 10c0/24d35d85f750f9e3e52f63b8ddd8fc8aa7bdd946c77b9ea4d6894d026c5c2c69109e8de3880a9970c906f624eb777c7d0c0a2072e6d41dadc7b36cce104b978c
+  checksum: 10c0/9e10676d29ce642eff8e4f7f9aa2fe6d8c5bebdc5ed107d2e6183be5d50699680b4e1d01a6096d4bec959d2337baf38fd5a39e9d541e9b1a28baf648bc0fefaa
   languageName: node
   linkType: hard
 
@@ -3317,15 +3305,16 @@ __metadata:
   linkType: hard
 
 "@octokit/request@npm:^10.0.6":
-  version: 10.0.7
-  resolution: "@octokit/request@npm:10.0.7"
+  version: 10.0.8
+  resolution: "@octokit/request@npm:10.0.8"
   dependencies:
-    "@octokit/endpoint": "npm:^11.0.2"
+    "@octokit/endpoint": "npm:^11.0.3"
     "@octokit/request-error": "npm:^7.0.2"
     "@octokit/types": "npm:^16.0.0"
     fast-content-type-parse: "npm:^3.0.0"
+    json-with-bigint: "npm:^3.5.3"
     universal-user-agent: "npm:^7.0.2"
-  checksum: 10c0/f789a75bf681b204ccd3d538921db662e148ed980005158d80ec4f16811e9ab73f375d4f30ef697852abd748a62f025060ea1b0c5198ec9c2e8d04e355064390
+  checksum: 10c0/7ee384dbeb489d4e00856eeaaf6a70060c61b036919c539809c3288e2ba14b8f3f63a5b16b8d5b7fdc93d7b6fa5c45bc3d181a712031279f6e192f019e52d7fe
   languageName: node
   linkType: hard
 
@@ -3380,14 +3369,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pnpm/npm-conf@npm:^2.1.0":
-  version: 2.3.1
-  resolution: "@pnpm/npm-conf@npm:2.3.1"
+"@pnpm/npm-conf@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@pnpm/npm-conf@npm:3.0.2"
   dependencies:
     "@pnpm/config.env-replace": "npm:^1.1.0"
     "@pnpm/network.ca-file": "npm:^1.0.1"
     config-chain: "npm:^1.1.11"
-  checksum: 10c0/778a3a34ff7d6000a2594d2a9821f873f737bc56367865718b2cf0ba5d366e49689efe7975148316d7afd8e6f1dcef7d736fbb6ea7ef55caadd1dc93a36bb302
+  checksum: 10c0/50026ae4cac7d5d055d4dd4b2886fbc41964db6179406cf2decf625e7a280fbfffd47380df584c085464deba060101169caca5f79e6a062b6c25b527bf60cb67
   languageName: node
   linkType: hard
 
@@ -3931,19 +3920,19 @@ __metadata:
   linkType: hard
 
 "@release-it/conventional-changelog@npm:^10.0.5":
-  version: 10.0.5
-  resolution: "@release-it/conventional-changelog@npm:10.0.5"
+  version: 10.0.6
+  resolution: "@release-it/conventional-changelog@npm:10.0.6"
   dependencies:
-    "@conventional-changelog/git-client": "npm:^2.5.1"
+    "@conventional-changelog/git-client": "npm:^2.6.0"
     concat-stream: "npm:^2.0.0"
-    conventional-changelog: "npm:^7.1.1"
-    conventional-changelog-angular: "npm:^8.1.0"
-    conventional-changelog-conventionalcommits: "npm:^9.1.0"
+    conventional-changelog: "npm:^7.2.0"
+    conventional-changelog-angular: "npm:^8.3.0"
+    conventional-changelog-conventionalcommits: "npm:^9.3.0"
     conventional-recommended-bump: "npm:^11.2.0"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.7.4"
   peerDependencies:
     release-it: ^18.0.0 || ^19.0.0
-  checksum: 10c0/a7a48c09532151ecc2ddb7e6420e3c54814f6a7c10279a4e0b378c07635a3323fe15ce1e85db530a83094fee7a2116a01b4f031eacbf4cbf9f7bd960f0589908
+  checksum: 10c0/d7812cfbbc34f7258385801393a1d88d7d6f76aeebb4fa2a884156f5382ba93f7f14be1f7b4d1f2b6982c1bf10e33c4ca3a8374fc2cde50cf4e1d1a929129da4
   languageName: node
   linkType: hard
 
@@ -4019,8 +4008,8 @@ __metadata:
   linkType: hard
 
 "@semantic-release/github@npm:^12.0.0, @semantic-release/github@npm:^12.0.5":
-  version: 12.0.5
-  resolution: "@semantic-release/github@npm:12.0.5"
+  version: 12.0.6
+  resolution: "@semantic-release/github@npm:12.0.6"
   dependencies:
     "@octokit/core": "npm:^7.0.0"
     "@octokit/plugin-paginate-rest": "npm:^14.0.0"
@@ -4041,13 +4030,13 @@ __metadata:
     url-join: "npm:^5.0.0"
   peerDependencies:
     semantic-release: ">=24.1.0"
-  checksum: 10c0/84d71bd79e93e9945267c949cebcc4a7052eed14c32744194421e7569634dbe81d2589a0dbc6b23f9f5708bd342fc8c757c3d016afff88a49f3e23163765e801
+  checksum: 10c0/2f6b24d73790dbe14e3ac08814fc56f069ec4c96a0e471eeb5247d934b525b54cee9a6d296e90edb6566bb309cf81a04084551e8201362dfd82ca436a2813706
   languageName: node
   linkType: hard
 
 "@semantic-release/npm@npm:^13.1.1, @semantic-release/npm@npm:^13.1.4":
-  version: 13.1.4
-  resolution: "@semantic-release/npm@npm:13.1.4"
+  version: 13.1.5
+  resolution: "@semantic-release/npm@npm:13.1.5"
   dependencies:
     "@actions/core": "npm:^3.0.0"
     "@semantic-release/error": "npm:^4.0.0"
@@ -4057,7 +4046,7 @@ __metadata:
     fs-extra: "npm:^11.0.0"
     lodash-es: "npm:^4.17.21"
     nerf-dart: "npm:^1.0.0"
-    normalize-url: "npm:^8.0.0"
+    normalize-url: "npm:^9.0.0"
     npm: "npm:^11.6.2"
     rc: "npm:^1.2.8"
     read-pkg: "npm:^10.0.0"
@@ -4066,7 +4055,7 @@ __metadata:
     tempy: "npm:^3.0.0"
   peerDependencies:
     semantic-release: ">=20.1.0"
-  checksum: 10c0/a0924893ccdb277fcfea65a5894f807f47b9155d0d04153adc874a25a9c4187eaff08e6b038e8408426545ee0a45760c19525f6308da143effb712ecdb8e6414
+  checksum: 10c0/940bfe3f7ec1189e100b81242835230ab3c14da58a5e2feaf43055fd432453ee7efbde93562daf083aedd73478b7f7b12b7dc63752af9e61b3e010043374c552
   languageName: node
   linkType: hard
 
@@ -4124,10 +4113,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sigstore/core@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@sigstore/core@npm:3.1.0"
-  checksum: 10c0/4f059ccfecfb5f86244c595dce27f40ec6f2e2aaf10011c6b5328765c74785e5410cef6b4392881e203d27537a5e89e4d01c546478474d395ce71b41f2b9e5b2
+"@sigstore/core@npm:^3.1.0, @sigstore/core@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@sigstore/core@npm:3.2.0"
+  checksum: 10c0/64a4abe361af3b56fd1689e195516759d8124b3033cd182888d007db0be9adc8825c5af350040b6a8eceeebe79c1296149c4d3afce7effca4a93fc00bb9373dc
   languageName: node
   linkType: hard
 
@@ -4139,26 +4128,26 @@ __metadata:
   linkType: hard
 
 "@sigstore/sign@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@sigstore/sign@npm:4.1.0"
+  version: 4.1.1
+  resolution: "@sigstore/sign@npm:4.1.1"
   dependencies:
+    "@gar/promise-retry": "npm:^1.0.2"
     "@sigstore/bundle": "npm:^4.0.0"
-    "@sigstore/core": "npm:^3.1.0"
+    "@sigstore/core": "npm:^3.2.0"
     "@sigstore/protobuf-specs": "npm:^0.5.0"
-    make-fetch-happen: "npm:^15.0.3"
+    make-fetch-happen: "npm:^15.0.4"
     proc-log: "npm:^6.1.0"
-    promise-retry: "npm:^2.0.1"
-  checksum: 10c0/9983972e3dacb8431aa84ab89eb676447baeb5c1b8df3c3a43113168569c333d910e262a7e19d49dbf7a421cf0b0f4695834d5ba9ec467cf9f955d44d3fd5053
+  checksum: 10c0/88a6e5d2ce49477a52574d5dd5f4531cbb3472435fad29730969b77988efb23bdd5ce031a74f738da5b24c950f99030704b75b8cc65d5179b56ce9ede9711784
   languageName: node
   linkType: hard
 
-"@sigstore/tuf@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@sigstore/tuf@npm:4.0.1"
+"@sigstore/tuf@npm:^4.0.1, @sigstore/tuf@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@sigstore/tuf@npm:4.0.2"
   dependencies:
     "@sigstore/protobuf-specs": "npm:^0.5.0"
     tuf-js: "npm:^4.1.0"
-  checksum: 10c0/ed2a33e1e90ca2e036c57f115eca48e3297b0c30329d6b8007974f4d4e8b09d9ea93bb0b92f4d83d9c8f939efd6f3284f8ef3dd8b6edca7c5c61a05f93e85974
+  checksum: 10c0/eb7ba5b9d4859948bfd5552a1c6d93f0d05b9482bf21dede53779ea429f833dcd13c3a52524596c556729d75d85326ce0a7d0857d3d23ef99784b0e94e948818
   languageName: node
   linkType: hard
 
@@ -4174,28 +4163,32 @@ __metadata:
   linkType: hard
 
 "@simple-libs/child-process-utils@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "@simple-libs/child-process-utils@npm:1.0.1"
+  version: 1.0.2
+  resolution: "@simple-libs/child-process-utils@npm:1.0.2"
   dependencies:
-    "@simple-libs/stream-utils": "npm:^1.1.0"
-    "@types/node": "npm:^22.0.0"
-  checksum: 10c0/3c875a4c0b36dba8948628a77ec9671a946123f664e5632f2a4897b8fc8235a78108ba1412e40f2b1682b4646b9f2a984f0b3dfff144ae76e708bb1b5d25d8ef
+    "@simple-libs/stream-utils": "npm:^1.2.0"
+  checksum: 10c0/a057603daf68a852d75bc6a840659291187b4bb5310e8d46e35dd5c1848047a15b40f6dd1917e17a533bd25d0a8ad75c48ef1a8301aad7e9a325c2b180e96cb6
   languageName: node
   linkType: hard
 
-"@simple-libs/stream-utils@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@simple-libs/stream-utils@npm:1.1.0"
-  dependencies:
-    "@types/node": "npm:^22.0.0"
-  checksum: 10c0/c8fbe6034fc2830bab2ad067667737c1eed096710a87b528c7c34ba17d0539049842d2fd37cf4ae5ae3a0d30fa6a0a341a61a147c70a278cb7ecaf6c383e9f20
+"@simple-libs/hosted-git-info@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@simple-libs/hosted-git-info@npm:1.0.2"
+  checksum: 10c0/6f22b598b9d37f3e37e409eb588126d14a68f62d52f6e2bb1d99745eb86de8843a02a6fbf7e7f4d026a07fcb1f98d0036d9dcb47363275fa86e67c237fadac75
+  languageName: node
+  linkType: hard
+
+"@simple-libs/stream-utils@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@simple-libs/stream-utils@npm:1.2.0"
+  checksum: 10c0/2788ac7b167d1b6c81b8c6fae2f5d9688b1f02ab31e9e15b33c9dc2ae920cf7de87869de10679be8957f9adb645c91c8919e271f3e34b6b4ec56daf725522dc7
   languageName: node
   linkType: hard
 
 "@sinclair/typebox@npm:^0.27.8":
-  version: 0.27.8
-  resolution: "@sinclair/typebox@npm:0.27.8"
-  checksum: 10c0/ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
+  version: 0.27.10
+  resolution: "@sinclair/typebox@npm:0.27.10"
+  checksum: 10c0/ca42a02817656dbdae464ed4bb8aca6ad4718d7618e270760fea84a834ad0ecc1a22eba51421f09e5047174571131356ff3b5d80d609ced775d631df7b404b0d
   languageName: node
   linkType: hard
 
@@ -4332,28 +4325,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/color-convert@npm:*":
-  version: 2.0.4
-  resolution: "@types/color-convert@npm:2.0.4"
+"@types/color-convert@npm:1":
+  version: 1.9.0
+  resolution: "@types/color-convert@npm:1.9.0"
   dependencies:
-    "@types/color-name": "npm:^1.1.0"
-  checksum: 10c0/fdd2cea0ccf593055c8d952760286a4c114ed72a9940798d13f159823bf71d40a6b124009865e2e066f062d6d5611b677ddb61fd0ed05f6494170454cc6457c2
+    "@types/color-name": "npm:*"
+  checksum: 10c0/544a9dc4eca60a627e76ec12faa0b343ceef8fbaf38cf51248386291b29fc89246c5c069db0c1fbf1b96420429159afc5eddd2b8b1fe952451c6b784ed66bad6
   languageName: node
   linkType: hard
 
-"@types/color-name@npm:^1.1.0":
-  version: 1.1.5
-  resolution: "@types/color-name@npm:1.1.5"
-  checksum: 10c0/ce566d98ab1c2622a2e9d9d1d5cbde403e731a4fc084e8b0f56e89901cd3c46981feafb797d4505918d5eb5a7fd897fce2332d489f450ddf1c58bc4986bd9d76
+"@types/color-name@npm:*":
+  version: 2.0.0
+  resolution: "@types/color-name@npm:2.0.0"
+  checksum: 10c0/f8c80199a1e1c38fb8e3bf26743e9fe1220e3991d6df42b7abdc36b3aa94abb90b038ce615d684d7e46b4423a79e6b272dd4fd690859d6f000663a646ea74bbf
   languageName: node
   linkType: hard
 
 "@types/color@npm:^3.0.6":
-  version: 3.0.6
-  resolution: "@types/color@npm:3.0.6"
+  version: 3.0.7
+  resolution: "@types/color@npm:3.0.7"
   dependencies:
-    "@types/color-convert": "npm:*"
-  checksum: 10c0/79267eeb67f9d11761aecee36bb1503fb8daa699b9ae7e036fc23a74380e5b130c5c0f6d7adafabba89256e46f36ee4d3e28e0ac7e107e8258550eae7d091acf
+    "@types/color-convert": "npm:1"
+  checksum: 10c0/86b1864f10c7508275626cf46349bd00bb85939f77afc898f5b4f74eaf3607a0c0a762590ce499173b77d740eadf8a0d08c36cdb3e77d0f48f9b0e1aedaeea06
   languageName: node
   linkType: hard
 
@@ -4425,9 +4418,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "@types/lodash@npm:4.17.23"
-  checksum: 10c0/9d9cbfb684e064a2b78aab9e220d398c9c2a7d36bc51a07b184ff382fa043a99b3d00c16c7f109b4eb8614118f4869678dbae7d5c6700ed16fb9340e26cc0bf6
+  version: 4.17.24
+  resolution: "@types/lodash@npm:4.17.24"
+  checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
   languageName: node
   linkType: hard
 
@@ -4448,20 +4441,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 24.10.1
-  resolution: "@types/node@npm:24.10.1"
+  version: 25.5.0
+  resolution: "@types/node@npm:25.5.0"
   dependencies:
-    undici-types: "npm:~7.16.0"
-  checksum: 10c0/d6bca7a78f550fbb376f236f92b405d676003a8a09a1b411f55920ef34286ee3ee51f566203920e835478784df52662b5b2af89159d9d319352e9ea21801c002
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^22.0.0":
-  version: 22.19.1
-  resolution: "@types/node@npm:22.19.1"
-  dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10c0/6edd93aea86da740cb7872626839cd6f4a67a049d3a3a6639cb592c620ec591408a30989ab7410008d1a0b2d4985ce50f1e488e79c033e4476d3bec6833b0a2f
+    undici-types: "npm:~7.18.0"
+  checksum: 10c0/70c508165b6758c4f88d4f91abca526c3985eee1985503d4c2bd994dbaf588e52ac57e571160f18f117d76e963570ac82bd20e743c18987e82564312b3b62119
   languageName: node
   linkType: hard
 
@@ -4515,31 +4499,21 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*":
-  version: 19.2.7
-  resolution: "@types/react@npm:19.2.7"
+  version: 19.2.14
+  resolution: "@types/react@npm:19.2.14"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10c0/a7b75f1f9fcb34badd6f84098be5e35a0aeca614bc91f93d2698664c0b2ba5ad128422bd470ada598238cebe4f9e604a752aead7dc6f5a92261d0c7f9b27cfd1
+  checksum: 10c0/7d25bf41b57719452d86d2ac0570b659210402707313a36ee612666bf11275a1c69824f8c3ee1fdca077ccfe15452f6da8f1224529b917050eb2d861e52b59b7
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18":
+"@types/react@npm:^18, @types/react@npm:^18.0.24":
   version: 18.3.28
   resolution: "@types/react@npm:18.3.28"
   dependencies:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.2.2"
   checksum: 10c0/683e19cd12b5c691215529af2e32b5ffbaccae3bf0ba93bfafa0e460e8dfee18423afed568be2b8eadf4b837c3749dd296a4f64e2d79f68fa66962c05f5af661
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18.0.24":
-  version: 18.3.27
-  resolution: "@types/react@npm:18.3.27"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    csstype: "npm:^3.2.2"
-  checksum: 10c0/a761d2f58de03d0714806cc65d32bb3d73fb33a08dd030d255b47a295e5fff2a775cf1c20b786824d8deb6454eaccce9bc6998d9899c14fc04bbd1b0b0b72897
   languageName: node
   linkType: hard
 
@@ -4778,11 +4752,11 @@ __metadata:
   linkType: hard
 
 "acorn@npm:^8.15.0, acorn@npm:^8.9.0":
-  version: 8.15.0
-  resolution: "acorn@npm:8.15.0"
+  version: 8.16.0
+  resolution: "acorn@npm:8.16.0"
   bin:
     acorn: bin/acorn
-  checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
+  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
   languageName: node
   linkType: hard
 
@@ -4824,26 +4798,26 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^6.12.4":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.1"
     fast-json-stable-stringify: "npm:^2.0.0"
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
-  checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  checksum: 10c0/a2bc39b0555dc9802c899f86990eb8eed6e366cddbf65be43d5aa7e4f3c4e1a199d5460fd7ca4fb3d864000dbbc049253b72faa83b3b30e641ca52cb29a68c22
   languageName: node
   linkType: hard
 
 "ajv@npm:^8.11.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
+  version: 8.18.0
+  resolution: "ajv@npm:8.18.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
+  checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
   languageName: node
   linkType: hard
 
@@ -4864,11 +4838,11 @@ __metadata:
   linkType: hard
 
 "ansi-escapes@npm:^7.0.0":
-  version: 7.2.0
-  resolution: "ansi-escapes@npm:7.2.0"
+  version: 7.3.0
+  resolution: "ansi-escapes@npm:7.3.0"
   dependencies:
     environment: "npm:^1.0.0"
-  checksum: 10c0/b562fd995761fa12f33be316950ee58fda489e125d331bcd9131434969a2eb55dc14e9405f214dcf4697c9d67c576ba0baf6e8f3d52058bf9222c97560b220cb
+  checksum: 10c0/068961d99f0ef28b661a4a9f84a5d645df93ccf3b9b93816cc7d46bbe1913321d4cdf156bb842a4e1e4583b7375c631fa963efb43001c4eb7ff9ab8f78fc0679
   languageName: node
   linkType: hard
 
@@ -4886,7 +4860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^6.0.1, ansi-regex@npm:^6.1.0":
+"ansi-regex@npm:^6.1.0, ansi-regex@npm:^6.2.2":
   version: 6.2.2
   resolution: "ansi-regex@npm:6.2.2"
   checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
@@ -4986,23 +4960,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arkregex@npm:0.0.4":
-  version: 0.0.4
-  resolution: "arkregex@npm:0.0.4"
+"arkregex@npm:0.0.5":
+  version: 0.0.5
+  resolution: "arkregex@npm:0.0.5"
   dependencies:
     "@ark/util": "npm:0.56.0"
-  checksum: 10c0/5cb89ac6482e0ce15aa93e6fa791b22e43b35419ff91965762a33a4cc4a92a039c71e9adf9a2e700b3819074e4b9df04245e38c4010a2baa5f3bcb38a6c66f0b
+  checksum: 10c0/1a39510e04d69b9287b9b53d3965afcc4ef27bdd9ff9c21a78092fcb841f35c11227d8476be66d2f76347deccfd10c202f395bd871383c328057ad004ffe7ebd
   languageName: node
   linkType: hard
 
 "arktype@npm:^2.1.15":
-  version: 2.1.28
-  resolution: "arktype@npm:2.1.28"
+  version: 2.2.0
+  resolution: "arktype@npm:2.2.0"
   dependencies:
     "@ark/schema": "npm:0.56.0"
     "@ark/util": "npm:0.56.0"
-    arkregex: "npm:0.0.4"
-  checksum: 10c0/5ca424ecb7acdf426785f95ddb1cf4b6c10123a44b16b71d8a13b0bb1e2573ae91949d2254421cdda0e6b815b603519a5631eeb707ee238bb7fceed1594e5dd0
+    arkregex: "npm:0.0.5"
+  checksum: 10c0/67c05dfe9654996c6129e68ce6c39188d4a3c6f1268cf78f028d6c98ab0b92954142853f03a41ecff029d56a0703824d2ca5d76525dab54a32de09a7145b374e
   languageName: node
   linkType: hard
 
@@ -5225,16 +5199,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.4.14":
-  version: 0.4.14
-  resolution: "babel-plugin-polyfill-corejs2@npm:0.4.14"
+"babel-plugin-polyfill-corejs2@npm:^0.4.14, babel-plugin-polyfill-corejs2@npm:^0.4.15":
+  version: 0.4.17
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.4.17"
   dependencies:
-    "@babel/compat-data": "npm:^7.27.7"
-    "@babel/helper-define-polyfill-provider": "npm:^0.6.5"
+    "@babel/compat-data": "npm:^7.28.6"
+    "@babel/helper-define-polyfill-provider": "npm:^0.6.8"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 10c0/d74cba0600a6508e86d220bde7164eb528755d91be58020e5ea92ea7fbb12c9d8d2c29246525485adfe7f68ae02618ec428f9a589cac6cbedf53cc3972ad7fbe
+  checksum: 10c0/1284960ea403c63b0dd598f338666c4b17d489aefee30b4da6a7313eff1d91edffb0ccf26341a6e5d94231684b74e016eade66b3921ea112f8b0e4980fa08a5c
   languageName: node
   linkType: hard
 
@@ -5250,14 +5224,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-regenerator@npm:^0.6.5":
-  version: 0.6.5
-  resolution: "babel-plugin-polyfill-regenerator@npm:0.6.5"
+"babel-plugin-polyfill-corejs3@npm:^0.14.0":
+  version: 0.14.2
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.14.2"
   dependencies:
-    "@babel/helper-define-polyfill-provider": "npm:^0.6.5"
+    "@babel/helper-define-polyfill-provider": "npm:^0.6.8"
+    core-js-compat: "npm:^3.48.0"
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 10c0/63aa8ed716df6a9277c6ab42b887858fa9f57a70cc1d0ae2b91bdf081e45d4502848cba306fb60b02f59f99b32fd02ff4753b373cac48ccdac9b7d19dd56f06d
+  checksum: 10c0/32f70442f142d0f5607f4b57c121c573b106e09da8659c0f03108a85bf1d09ba5bdc89595a82b34ff76c19f1faf3d1c831b56166f03babf69c024f36da77c3bf
+  languageName: node
+  linkType: hard
+
+"babel-plugin-polyfill-regenerator@npm:^0.6.5, babel-plugin-polyfill-regenerator@npm:^0.6.6":
+  version: 0.6.8
+  resolution: "babel-plugin-polyfill-regenerator@npm:0.6.8"
+  dependencies:
+    "@babel/helper-define-polyfill-provider": "npm:^0.6.8"
+  peerDependencies:
+    "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+  checksum: 10c0/7c8b2497c29fa880e0acdc8e7b93e29b81b154179b83beb0476eb2c4e7a78b6b42fc35c2554ca250c9bd6d39941eaf75416254b8592ce50979f9a12e1d51c049
   languageName: node
   linkType: hard
 
@@ -5382,6 +5368,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.2.3, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -5389,12 +5382,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.8.25":
-  version: 2.8.32
-  resolution: "baseline-browser-mapping@npm:2.8.32"
+"baseline-browser-mapping@npm:^2.9.0":
+  version: 2.10.10
+  resolution: "baseline-browser-mapping@npm:2.10.10"
   bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/6c4aa0338ad177e946a27412de11769fb6474389a59cc03e13e0538d7285a94052a11525d46bb605ddb913a0c8a1180292d6f05cd4d6bc05bbf597c26bf5ce66
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10c0/39dee9d955a5e017852f338cb9057feee8d938c82f217d63158f04ccdbbc1c19e80bbed8d15223e3d410ee8b3703829d41fd7eb345e6e44230034ea9adaf8a1d
   languageName: node
   linkType: hard
 
@@ -5492,12 +5485,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
+"brace-expansion@npm:^2.0.2":
   version: 2.0.2
   resolution: "brace-expansion@npm:2.0.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.2":
+  version: 5.0.4
+  resolution: "brace-expansion@npm:5.0.4"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
   languageName: node
   linkType: hard
 
@@ -5510,18 +5512,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.20.4, browserslist@npm:^4.24.0, browserslist@npm:^4.28.0":
-  version: 4.28.0
-  resolution: "browserslist@npm:4.28.0"
+"browserslist@npm:^4.20.4, browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
+  version: 4.28.1
+  resolution: "browserslist@npm:4.28.1"
   dependencies:
-    baseline-browser-mapping: "npm:^2.8.25"
-    caniuse-lite: "npm:^1.0.30001754"
-    electron-to-chromium: "npm:^1.5.249"
+    baseline-browser-mapping: "npm:^2.9.0"
+    caniuse-lite: "npm:^1.0.30001759"
+    electron-to-chromium: "npm:^1.5.263"
     node-releases: "npm:^2.0.27"
-    update-browserslist-db: "npm:^1.1.4"
+    update-browserslist-db: "npm:^1.2.0"
   bin:
     browserslist: cli.js
-  checksum: 10c0/4284fd568f7d40a496963083860d488cb2a89fb055b6affd316bebc59441fec938e090b3e62c0ee065eb0bc88cd1bc145f4300a16c75f3f565621c5823715ae1
+  checksum: 10c0/545a5fa9d7234e3777a7177ec1e9134bb2ba60a69e6b95683f6982b1473aad347c77c1264ccf2ac5dea609a9731fbfbda6b85782bdca70f80f86e28a402504bd
   languageName: node
   linkType: hard
 
@@ -5601,9 +5603,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^20.0.0, cacache@npm:^20.0.1, cacache@npm:^20.0.3":
-  version: 20.0.3
-  resolution: "cacache@npm:20.0.3"
+"cacache@npm:^20.0.0, cacache@npm:^20.0.1, cacache@npm:^20.0.4":
+  version: 20.0.4
+  resolution: "cacache@npm:20.0.4"
   dependencies:
     "@npmcli/fs": "npm:^5.0.0"
     fs-minipass: "npm:^3.0.0"
@@ -5615,8 +5617,7 @@ __metadata:
     minipass-pipeline: "npm:^1.2.4"
     p-map: "npm:^7.0.2"
     ssri: "npm:^13.0.0"
-    unique-filename: "npm:^5.0.0"
-  checksum: 10c0/c7da1ca694d20e8f8aedabd21dc11518f809a7d2b59aa76a1fc655db5a9e62379e465c157ddd2afe34b19230808882288effa6911b2de26a088a6d5645123462
+  checksum: 10c0/539bf4020e44ba9ca5afc2ec435623ed7e0dd80c020097677e6b4a0545df5cc9d20b473212d01209c8b4aea43c0d095af0bb6da97bcb991642ea6fac0d7c462b
   languageName: node
   linkType: hard
 
@@ -5710,10 +5711,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001754":
-  version: 1.0.30001759
-  resolution: "caniuse-lite@npm:1.0.30001759"
-  checksum: 10c0/b0f415960ba34995cda18e0d25c4e602f6917b9179290a76bdd0311423505b78cc93e558a90c98a22a1cc6b1781ab720ef6beea24ec7e29a1c1164ca72eac3a2
+"caniuse-lite@npm:^1.0.30001759":
+  version: 1.0.30001780
+  resolution: "caniuse-lite@npm:1.0.30001780"
+  checksum: 10c0/8a88f39758a228852d6f3ac92362ecb7694b1b2b022f194d8dfe59123ad40a5de6202bf2dff0fe316bb3d5ca9caf316c22056e0da693459c3be2771cde4f4bf9
   languageName: node
   linkType: hard
 
@@ -5817,14 +5818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.0.0":
-  version: 4.3.1
-  resolution: "ci-info@npm:4.3.1"
-  checksum: 10c0/7dd82000f514d76ddfe7775e4cb0d66e5c638f5fa0e2a3be29557e898da0d32ac04f231217d414d07fb968b1fbc6d980ee17ddde0d2c516f23da9cfff608f6c1
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:^4.3.1, ci-info@npm:^4.4.0":
+"ci-info@npm:^4.0.0, ci-info@npm:^4.3.1, ci-info@npm:^4.4.0":
   version: 4.4.0
   resolution: "ci-info@npm:4.4.0"
   checksum: 10c0/44156201545b8dde01aa8a09ee2fe9fc7a73b1bef9adbd4606c9f61c8caeeb73fb7a575c88b0443f7b4edb5ee45debaa59ed54ba5f99698339393ca01349eb3a
@@ -5832,11 +5826,9 @@ __metadata:
   linkType: hard
 
 "cidr-regex@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "cidr-regex@npm:5.0.1"
-  dependencies:
-    ip-regex: "npm:5.0.0"
-  checksum: 10c0/befed1513a74eb421d100606b58e528222981dc9ce9b68ad75a95c5f2d7f1c31d6d3a81a31fea5f943d6e64947efecc405e4eb9a3dc11d213c74c532ed0666f7
+  version: 5.0.3
+  resolution: "cidr-regex@npm:5.0.3"
+  checksum: 10c0/98c41fbc343c5f01fd02b3fa6c1e1c7f1dac5b636372a86afd3874bd778404178a9ac81cb8c510ed94a027173f14e0cd5b463b5027110f6642f86e2cb18f0714
   languageName: node
   linkType: hard
 
@@ -5850,9 +5842,9 @@ __metadata:
   linkType: hard
 
 "citty@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "citty@npm:0.2.0"
-  checksum: 10c0/da72051262ec0e0390dc9800e16bae72a5c85d61982e4f74e3c502d08a3099428964405eb1b4cdc07a7fd5658f78db97c0111c503cde592a41e75a299ac45fb5
+  version: 0.2.1
+  resolution: "citty@npm:0.2.1"
+  checksum: 10c0/504ac5aeb076f750bf5f25d40c730083e8ed6112eac2f00dbe341a223c46ad16893ce73dfdb55b2d0da505100b9678968ee0443637c45b21917db48daa5a6977
   languageName: node
   linkType: hard
 
@@ -5885,16 +5877,6 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:5.0.0"
   checksum: 10c0/1aa8b6772eed1f678a9dcf6e02c74c59f26b6fdad26eaaca1dc6a367ff19c924315836b6143484c2686366758e05396f1ac0f32aaa70481b11d8e23790947ca0
-  languageName: node
-  linkType: hard
-
-"cli-columns@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "cli-columns@npm:4.0.0"
-  dependencies:
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10c0/f724c874dba09376f7b2d6c70431d8691d5871bd5d26c6f658dd56b514e668ed5f5b8d803fb7e29f4000fc7f3a6d038d415b892ae7fa3dcd9cc458c07df17871
   languageName: node
   linkType: hard
 
@@ -6242,12 +6224,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:^8.0.0, conventional-changelog-angular@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "conventional-changelog-angular@npm:8.1.0"
+"conventional-changelog-angular@npm:^8.0.0, conventional-changelog-angular@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "conventional-changelog-angular@npm:8.3.0"
   dependencies:
     compare-func: "npm:^2.0.0"
-  checksum: 10c0/b82aab869117fd9bd6ccfa960521e7638d3c2a3599c95fd5ba30d3b3fe972b5f819af4d57229f2973a7129ea18546cdf5822004565cab1ee35355cc90ac4588f
+  checksum: 10c0/bab87fa741a25e4fb623e2629912a5e592de5ed616398bee0cd9779dc950aae2a78ac48a6f4268cbb5f5544bb33644e01c7b40cea378bb9763ae5304cc22efc2
   languageName: node
   linkType: hard
 
@@ -6260,12 +6242,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "conventional-changelog-conventionalcommits@npm:9.1.0"
+"conventional-changelog-conventionalcommits@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "conventional-changelog-conventionalcommits@npm:9.3.0"
   dependencies:
     compare-func: "npm:^2.0.0"
-  checksum: 10c0/b1dfbb8ce5983bb80837c35f089fb0f9603a1b067f34be680f88fde20871792e461e29d119d468bc293f38a1ca916c1c40a841f8c049a0a1efaa40582f4fecc9
+  checksum: 10c0/36be9435bb1f6e97bc729a1e69471851b6621054980617dc9a82c03221de5f9c21cd2369308c364f89b2383bd596071f90c8c71efdbe7a2908f91a935685fc76
   languageName: node
   linkType: hard
 
@@ -6276,35 +6258,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-writer@npm:^8.0.0, conventional-changelog-writer@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "conventional-changelog-writer@npm:8.2.0"
+"conventional-changelog-writer@npm:^8.0.0, conventional-changelog-writer@npm:^8.3.0":
+  version: 8.4.0
+  resolution: "conventional-changelog-writer@npm:8.4.0"
   dependencies:
+    "@simple-libs/stream-utils": "npm:^1.2.0"
     conventional-commits-filter: "npm:^5.0.0"
     handlebars: "npm:^4.7.7"
     meow: "npm:^13.0.0"
     semver: "npm:^7.5.2"
   bin:
     conventional-changelog-writer: dist/cli/index.js
-  checksum: 10c0/e25052bb366ecee6389326fd5b7d3ecbd6f6a65439f45b5a2b1d4096baeb1bbfa93cd6bea686f419423265db5bbb02870a014cb92f43f972c00191c60711e9b6
+  checksum: 10c0/d657bf74c470e5d515d3a07814d266e6e2aea018e6867bfefa4bc486bb3f948b47b01936d65e46b3090111823364c21c201f9fbe875b1fc805cdf884bb032bc1
   languageName: node
   linkType: hard
 
-"conventional-changelog@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "conventional-changelog@npm:7.1.1"
+"conventional-changelog@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "conventional-changelog@npm:7.2.0"
   dependencies:
-    "@conventional-changelog/git-client": "npm:^2.5.1"
+    "@conventional-changelog/git-client": "npm:^2.6.0"
+    "@simple-libs/hosted-git-info": "npm:^1.0.2"
     "@types/normalize-package-data": "npm:^2.4.4"
     conventional-changelog-preset-loader: "npm:^5.0.0"
-    conventional-changelog-writer: "npm:^8.2.0"
-    conventional-commits-parser: "npm:^6.2.0"
+    conventional-changelog-writer: "npm:^8.3.0"
+    conventional-commits-parser: "npm:^6.3.0"
     fd-package-json: "npm:^2.0.0"
     meow: "npm:^13.0.0"
     normalize-package-data: "npm:^7.0.0"
   bin:
     conventional-changelog: dist/cli/index.js
-  checksum: 10c0/8f2c36b7a463bdedc9f919a50458a061b8017d003452b5bc648a6c43a0affe2e76ed9cb5933aa55ad4d6c99061c0b9a567ec5c528333593ec0f210151e1e11b7
+  checksum: 10c0/2383d70ae372e6c46c7354e6a697c291b9f977cb5166507b0f187ccbee5cb0c8d6a96ec295e1212cd6abaefc5b00a56e9fb15c12ddc4c3a859f4eb765061e566
   languageName: node
   linkType: hard
 
@@ -6329,14 +6313,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-commits-parser@npm:^6.0.0, conventional-commits-parser@npm:^6.1.0, conventional-commits-parser@npm:^6.2.0":
-  version: 6.2.1
-  resolution: "conventional-commits-parser@npm:6.2.1"
+"conventional-commits-parser@npm:^6.0.0, conventional-commits-parser@npm:^6.1.0, conventional-commits-parser@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "conventional-commits-parser@npm:6.3.0"
   dependencies:
+    "@simple-libs/stream-utils": "npm:^1.2.0"
     meow: "npm:^13.0.0"
   bin:
     conventional-commits-parser: dist/cli/index.js
-  checksum: 10c0/217b3fff627802f7fd7cb09bdfe897aa76986865543dfaa99b7957e4717d039e1e12c4a9b72706f098a5716bbbbdae540ef0b2429f7219d5fc5be0f190f1bc1e
+  checksum: 10c0/7b152db0b63617fb5f993c3422942c05f48ff42fef4350d7e73b1d8a9f24489050b126478f2aabee5e45f205dbd02cb0b486e4bb865f9c0b18c35b4d13952b25
   languageName: node
   linkType: hard
 
@@ -6369,12 +6354,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.43.0":
-  version: 3.47.0
-  resolution: "core-js-compat@npm:3.47.0"
+"core-js-compat@npm:^3.43.0, core-js-compat@npm:^3.48.0":
+  version: 3.49.0
+  resolution: "core-js-compat@npm:3.49.0"
   dependencies:
-    browserslist: "npm:^4.28.0"
-  checksum: 10c0/71da415899633120db7638dd7b250eee56031f63c4560dcba8eeeafd1168fae171d59b223e3fd2e0aa543a490d64bac7d946764721e2c05897056fdfb22cce33
+    browserslist: "npm:^4.28.1"
+  checksum: 10c0/546e64b7ce45f724825bc13c1347f35c0459a6e71c0dcccff3ec21fbff463f5b0b97fc1220e6d90302153863489301793276fe2bf96f46001ff555ead4140308
   languageName: node
   linkType: hard
 
@@ -6411,8 +6396,8 @@ __metadata:
   linkType: hard
 
 "cosmiconfig@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "cosmiconfig@npm:9.0.0"
+  version: 9.0.1
+  resolution: "cosmiconfig@npm:9.0.1"
   dependencies:
     env-paths: "npm:^2.2.1"
     import-fresh: "npm:^3.3.0"
@@ -6423,7 +6408,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
+  checksum: 10c0/a5d4d95599687532ee072bca60170133c24d4e08cd795529e0f22c6ce5fde9409eaf4f26e36e3d671f43270ef858fc68f3c7b0ec28e58fac7ddebda5b7725306
   languageName: node
   linkType: hard
 
@@ -6561,7 +6546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -6621,14 +6606,14 @@ __metadata:
   linkType: hard
 
 "dedent@npm:^1.0.0":
-  version: 1.7.0
-  resolution: "dedent@npm:1.7.0"
+  version: 1.7.2
+  resolution: "dedent@npm:1.7.2"
   peerDependencies:
     babel-plugin-macros: ^3.1.0
   peerDependenciesMeta:
     babel-plugin-macros:
       optional: true
-  checksum: 10c0/c5e8a8beb5072bd5e520cb64b27a82d7ec3c2a63ee5ce47dbc2a05d5b7700cefd77a992a752cd0a8b1d979c1db06b14fb9486e805f3ad6088eda6e07cd9bf2d5
+  checksum: 10c0/acaff07cac355b93f17b1b17ebbb84d3cc55af6ab4b7814c3f505e061903e168bc6bf9ddce331552d64dee1525f0b4c549c9ade46aebfac6f69caaed74e90751
   languageName: node
   linkType: hard
 
@@ -6661,12 +6646,12 @@ __metadata:
   linkType: hard
 
 "default-browser@npm:^5.2.1":
-  version: 5.4.0
-  resolution: "default-browser@npm:5.4.0"
+  version: 5.5.0
+  resolution: "default-browser@npm:5.5.0"
   dependencies:
     bundle-name: "npm:^4.1.0"
     default-browser-id: "npm:^5.0.0"
-  checksum: 10c0/a49ddd0c7b1a319163f64a5fc68ebb45a98548ea23a3155e04518f026173d85cfa2f451b646366c36c8f70b01e4cb773e23d1d22d2c61d8b84e5fbf151b4b609
+  checksum: 10c0/576593b617b17a7223014b4571bfe1c06a2581a4eb8b130985d90d253afa3f40999caec70eb0e5776e80d4af6a41cce91018cd3f86e57ad578bf59e46fb19abe
   languageName: node
   linkType: hard
 
@@ -6778,7 +6763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0":
+"depd@npm:2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
@@ -6882,9 +6867,9 @@ __metadata:
   linkType: hard
 
 "dotenv@npm:^17.2.3":
-  version: 17.2.4
-  resolution: "dotenv@npm:17.2.4"
-  checksum: 10c0/901aeee9cb40860291bdb452f6ca66aada78438331a026b0bd86fd41b94a79752dbc6a8971f4f26e6cafef11b4a27bb12ea99c0cbe7dfa61791f194727f799e5
+  version: 17.3.1
+  resolution: "dotenv@npm:17.3.1"
+  checksum: 10c0/c78e0c2d5a549c751e544cc60e2b95e7cb67e0c551f42e094d161c6b297aa44b630a3c2dcacf5569e529a6c2a6b84e2ab9be8d37b299d425df5a18b81ce4a35f
   languageName: node
   linkType: hard
 
@@ -6929,10 +6914,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.249":
-  version: 1.5.263
-  resolution: "electron-to-chromium@npm:1.5.263"
-  checksum: 10c0/d9ba38c5e87f4f1c78e64c7dcc2a32f764664cdbab3c576f23cb3d66a1c3ca1836ecfa00768ab4cd921a0832d09f65555f86eadb926f2cfd3fe93d6c57b8f583
+"electron-to-chromium@npm:^1.5.263":
+  version: 1.5.321
+  resolution: "electron-to-chromium@npm:1.5.321"
+  checksum: 10c0/1272703857b8ac9868a75d495c141b71bad36adcb0df53393196da3819012fa2596ba48fccac750bdcb746a523d2a33543b36e9dc0ae727a55e7a6f00b2b155a
   languageName: node
   linkType: hard
 
@@ -6985,15 +6970,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encoding@npm:^0.1.13":
-  version: 0.1.13
-  resolution: "encoding@npm:0.1.13"
-  dependencies:
-    iconv-lite: "npm:^0.6.2"
-  checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
-  languageName: node
-  linkType: hard
-
 "end-of-stream@npm:^1.1.0":
   version: 1.4.5
   resolution: "end-of-stream@npm:1.4.5"
@@ -7034,13 +7010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"err-code@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "err-code@npm:2.0.3"
-  checksum: 10c0/b642f7b4dd4a376e954947550a3065a9ece6733ab8e51ad80db727aaae0817c2e99b02a97a3d6cecc648a97848305e728289cf312d09af395403a90c9d4d8a66
-  languageName: node
-  linkType: hard
-
 "error-ex@npm:^1.3.1":
   version: 1.3.4
   resolution: "error-ex@npm:1.3.4"
@@ -7059,9 +7028,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.17.5, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0":
-  version: 1.24.0
-  resolution: "es-abstract@npm:1.24.0"
+"es-abstract@npm:^1.17.5, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0, es-abstract@npm:^1.24.1":
+  version: 1.24.1
+  resolution: "es-abstract@npm:1.24.1"
   dependencies:
     array-buffer-byte-length: "npm:^1.0.2"
     arraybuffer.prototype.slice: "npm:^1.0.4"
@@ -7117,7 +7086,7 @@ __metadata:
     typed-array-length: "npm:^1.0.7"
     unbox-primitive: "npm:^1.1.0"
     which-typed-array: "npm:^1.1.19"
-  checksum: 10c0/b256e897be32df5d382786ce8cce29a1dd8c97efbab77a26609bd70f2ed29fbcfc7a31758cb07488d532e7ccccdfca76c1118f2afe5a424cdc05ca007867c318
+  checksum: 10c0/fca062ef8b5daacf743732167d319a212d45cb655b0bb540821d38d715416ae15b04b84fc86da9e2c89135aa7b337337b6c867f84dcde698d75d55688d5d765c
   languageName: node
   linkType: hard
 
@@ -7136,26 +7105,27 @@ __metadata:
   linkType: hard
 
 "es-iterator-helpers@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "es-iterator-helpers@npm:1.2.1"
+  version: 1.3.1
+  resolution: "es-iterator-helpers@npm:1.3.1"
   dependencies:
     call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.3"
+    call-bound: "npm:^1.0.4"
     define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.6"
+    es-abstract: "npm:^1.24.1"
     es-errors: "npm:^1.3.0"
-    es-set-tostringtag: "npm:^2.0.3"
+    es-set-tostringtag: "npm:^2.1.0"
     function-bind: "npm:^1.1.2"
-    get-intrinsic: "npm:^1.2.6"
+    get-intrinsic: "npm:^1.3.0"
     globalthis: "npm:^1.0.4"
     gopd: "npm:^1.2.0"
     has-property-descriptors: "npm:^1.0.2"
     has-proto: "npm:^1.2.0"
     has-symbols: "npm:^1.1.0"
     internal-slot: "npm:^1.1.0"
-    iterator.prototype: "npm:^1.1.4"
+    iterator.prototype: "npm:^1.1.5"
+    math-intrinsics: "npm:^1.1.0"
     safe-array-concat: "npm:^1.1.3"
-  checksum: 10c0/97e3125ca472d82d8aceea11b790397648b52c26d8768ea1c1ee6309ef45a8755bb63225a43f3150c7591cffc17caf5752459f1e70d583b4184370a8f04ebd2f
+  checksum: 10c0/39837bb23bf6e53a066ae6a218c62bbc2c3cdd7da19336104bd7a16521675fcd9a61abe9cecf37992616584bee1d72f057bac66f2115fcf4840c934df6e96689
   languageName: node
   linkType: hard
 
@@ -7168,7 +7138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-set-tostringtag@npm:^2.0.3, es-set-tostringtag@npm:^2.1.0":
+"es-set-tostringtag@npm:^2.1.0":
   version: 2.1.0
   resolution: "es-set-tostringtag@npm:2.1.0"
   dependencies:
@@ -7487,11 +7457,11 @@ __metadata:
   linkType: hard
 
 "esquery@npm:^1.4.2":
-  version: 1.6.0
-  resolution: "esquery@npm:1.6.0"
+  version: 1.7.0
+  resolution: "esquery@npm:1.7.0"
   dependencies:
     estraverse: "npm:^5.1.0"
-  checksum: 10c0/cb9065ec605f9da7a76ca6dadb0619dfb611e37a81e318732977d90fab50a256b95fee2d925fba7c2f3f0523aa16f91587246693bc09bc34d5a59575fe6e93d2
+  checksum: 10c0/77d5173db450b66f3bc685d11af4c90cffeedb340f34a39af96d43509a335ce39c894fd79233df32d38f5e4e219fa0f7076f6ec90bae8320170ba082c0db4793
   languageName: node
   linkType: hard
 
@@ -7543,13 +7513,6 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
-  languageName: node
-  linkType: hard
-
-"exec-async@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "exec-async@npm:2.2.0"
-  checksum: 10c0/9c70693a3d9f53e19cc8ecf26c3b3fc7125bf40051a71cba70d71161d065a6091d3ab1924c56ac1edd68cb98b9fbef29f83e45dcf67ee6b6c4826e0f898ac039
   languageName: node
   linkType: hard
 
@@ -7658,20 +7621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-constants@npm:~17.1.7":
-  version: 17.1.7
-  resolution: "expo-constants@npm:17.1.7"
-  dependencies:
-    "@expo/config": "npm:~11.0.12"
-    "@expo/env": "npm:~1.0.7"
-  peerDependencies:
-    expo: "*"
-    react-native: "*"
-  checksum: 10c0/84ef3b9de11aa7b55cf5867213b7211bcee982eda0a630a657e22671be2d85bed7f3f092acdecc5bb6bc940c611212657532a6e53f62b384414988d988e96a26
-  languageName: node
-  linkType: hard
-
-"expo-constants@npm:~17.1.8":
+"expo-constants@npm:~17.1.7, expo-constants@npm:~17.1.8":
   version: 17.1.8
   resolution: "expo-constants@npm:17.1.8"
   dependencies:
@@ -7716,9 +7666,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-modules-autolinking@npm:2.1.14":
-  version: 2.1.14
-  resolution: "expo-modules-autolinking@npm:2.1.14"
+"expo-modules-autolinking@npm:2.1.15":
+  version: 2.1.15
+  resolution: "expo-modules-autolinking@npm:2.1.15"
   dependencies:
     "@expo/spawn-async": "npm:^1.7.2"
     chalk: "npm:^4.1.0"
@@ -7729,7 +7679,7 @@ __metadata:
     resolve-from: "npm:^5.0.0"
   bin:
     expo-modules-autolinking: bin/expo-modules-autolinking.js
-  checksum: 10c0/3d416a5ca69c95f462f6aa138ebc5ef6ea4f57e668f773235576f39f21285cb78c9a9b6b499603ec578903922f4e1c6aef62f3cc3156a1525f4af863cd3c3532
+  checksum: 10c0/f5e224c7e58b3ce1d5f939345c9a4c6b91d504b326618c6a94d9a1469e174fe0b2c23891bd4957475dd9b33b7402a0497c331c398503c38914f8443183c28db2
   languageName: node
   linkType: hard
 
@@ -7756,8 +7706,8 @@ __metadata:
   linkType: hard
 
 "expo@npm:~53.0.26":
-  version: 53.0.26
-  resolution: "expo@npm:53.0.26"
+  version: 53.0.27
+  resolution: "expo@npm:53.0.27"
   dependencies:
     "@babel/runtime": "npm:^7.20.0"
     "@expo/cli": "npm:0.24.24"
@@ -7772,7 +7722,7 @@ __metadata:
     expo-file-system: "npm:~18.1.11"
     expo-font: "npm:~13.3.2"
     expo-keep-awake: "npm:~14.1.4"
-    expo-modules-autolinking: "npm:2.1.14"
+    expo-modules-autolinking: "npm:2.1.15"
     expo-modules-core: "npm:2.5.0"
     react-native-edge-to-edge: "npm:1.6.0"
     whatwg-url-without-unicode: "npm:8.0.0-3"
@@ -7793,7 +7743,7 @@ __metadata:
     expo: bin/cli
     expo-modules-autolinking: bin/autolinking
     fingerprint: bin/fingerprint
-  checksum: 10c0/343f474d4e9e96bef4c14fe5d16339f06d0fca11cab494b549f6ecb74d1fb6bb4e7f9d99b928d758c48adc671c7cd13a239cd79e62a9ea9454cff09d3cbe0c74
+  checksum: 10c0/fe76ca4a5ec68f0dc8f20a60b9fc1116c5a41f02f9cb9c1fbecfed5d747a1567db4535c9505fdee744e677df5f7c17bbe2519ffe611757d60de2b8bc3174aa8c
   languageName: node
   linkType: hard
 
@@ -7846,9 +7796,9 @@ __metadata:
   linkType: hard
 
 "fast-is-equal@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "fast-is-equal@npm:1.2.4"
-  checksum: 10c0/bcb834ad7ebda4bcc521436c69b200e490ad4c096014e7853886a88e96e9676832fe0c6a0292593d349ba5f9ef0bbaeb41e3d8e129559784dd415d4277ce0a7f
+  version: 1.2.6
+  resolution: "fast-is-equal@npm:1.2.6"
+  checksum: 10c0/c1dc96dacb96ce7a62519349dfd85c3662a73d8391f448a6fdc636aae0b0fd68df494d080c8336a7e1def689c3cc2fc4d0360ac967e7794e46be36a47b477eaa
   languageName: node
   linkType: hard
 
@@ -7881,11 +7831,11 @@ __metadata:
   linkType: hard
 
 "fastq@npm:^1.6.0":
-  version: 1.19.1
-  resolution: "fastq@npm:1.19.1"
+  version: 1.20.1
+  resolution: "fastq@npm:1.20.1"
   dependencies:
     reusify: "npm:^1.0.4"
-  checksum: 10c0/ebc6e50ac7048daaeb8e64522a1ea7a26e92b3cee5cd1c7f2316cdca81ba543aa40a136b53891446ea5c3a67ec215fbaca87ad405f102dd97012f62916905630
+  checksum: 10c0/e5dd725884decb1f11e5c822221d76136f239d0236f176fab80b7b8f9e7619ae57e6b4e5b73defc21e6b9ef99437ee7b545cff8e6c2c337819633712fa9d352e
   languageName: node
   linkType: hard
 
@@ -8102,9 +8052,9 @@ __metadata:
   linkType: hard
 
 "flow-parser@npm:0.*":
-  version: 0.292.0
-  resolution: "flow-parser@npm:0.292.0"
-  checksum: 10c0/99734b7e301382bdffa3bf978d2d4d4b267bf9e9d1fb2e28b6166f21a3851a31961751f17d8cdfb76fa035f6ff0d8851eea8cd562781da4585dbb77812c23e75
+  version: 0.306.0
+  resolution: "flow-parser@npm:0.306.0"
+  checksum: 10c0/0db9982618caa4567ff66801307ab1524030f7d6b7ebceec7903dabf82b291e20baad88104e61b267debee2e0c21f3ecb63f5f3b540a376c57d992335a609185
   languageName: node
   linkType: hard
 
@@ -8141,7 +8091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:0.5.2":
+"fresh@npm:~0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
@@ -8170,13 +8120,13 @@ __metadata:
   linkType: hard
 
 "fs-extra@npm:^11.0.0":
-  version: 11.3.2
-  resolution: "fs-extra@npm:11.3.2"
+  version: 11.3.4
+  resolution: "fs-extra@npm:11.3.4"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
-  checksum: 10c0/f5d629e1bb646d5dedb4d8b24c5aad3deb8cc1d5438979d6f237146cd10e113b49a949ae1b54212c2fbc98e2d0995f38009a9a1d0520f0287943335e65fe919b
+  checksum: 10c0/e08276f767a62496ae97d711aaa692c6a478177f24a85979b6a2881c9db9c68b8c2ad5da0bcf92c0b2a474cea6e935ec245656441527958fd8372cb647087df0
   languageName: node
   linkType: hard
 
@@ -8271,10 +8221,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.3.0":
-  version: 1.4.0
-  resolution: "get-east-asian-width@npm:1.4.0"
-  checksum: 10c0/4e481d418e5a32061c36fbb90d1b225a254cc5b2df5f0b25da215dcd335a3c111f0c2023ffda43140727a9cafb62dac41d022da82c08f31083ee89f714ee3b83
+"get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "get-east-asian-width@npm:1.5.0"
+  checksum: 10c0/bff8bbc8d81790b9477f7aa55b1806b9f082a8dc1359fff7bd8b96939622c86b729685afc2bfeb22def1fc6ef1e5228e4d87dd4e6da60bc43a5edfb03c4ee167
   languageName: node
   linkType: hard
 
@@ -8481,14 +8431,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "glob@npm:13.0.0"
+"glob@npm:^13.0.0, glob@npm:^13.0.6":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
   dependencies:
-    minimatch: "npm:^10.1.1"
-    minipass: "npm:^7.1.2"
-    path-scurry: "npm:^2.0.0"
-  checksum: 10c0/8e2f5821f3f7c312dd102e23a15b80c79e0837a9872784293ba2e15ec73b3f3749a49a42a31bfcb4e52c84820a474e92331c2eebf18819d20308f5c33876630a
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
   languageName: node
   linkType: hard
 
@@ -8799,16 +8749,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-errors@npm:2.0.0":
-  version: 2.0.0
-  resolution: "http-errors@npm:2.0.0"
+"http-errors@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
   dependencies:
-    depd: "npm:2.0.0"
-    inherits: "npm:2.0.4"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:2.0.1"
-    toidentifier: "npm:1.0.1"
-  checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
   languageName: node
   linkType: hard
 
@@ -8867,21 +8817,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.6.2":
-  version: 0.6.3
-  resolution: "iconv-lite@npm:0.6.3"
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "iconv-lite@npm:0.7.0"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10c0/2382400469071c55b6746c531eed5fa4d033e5db6690b7331fb2a5f59a30d7a9782932e92253db26df33c1cf46fa200a3fbe524a2a7c62037c762283f188ec2f
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
   languageName: node
   linkType: hard
 
@@ -9006,7 +8947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -9034,18 +8975,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"init-package-json@npm:^8.2.4":
-  version: 8.2.4
-  resolution: "init-package-json@npm:8.2.4"
+"init-package-json@npm:^8.2.5":
+  version: 8.2.5
+  resolution: "init-package-json@npm:8.2.5"
   dependencies:
     "@npmcli/package-json": "npm:^7.0.0"
     npm-package-arg: "npm:^13.0.0"
     promzard: "npm:^3.0.1"
     read: "npm:^5.0.1"
     semver: "npm:^7.7.2"
-    validate-npm-package-license: "npm:^3.0.4"
     validate-npm-package-name: "npm:^7.0.0"
-  checksum: 10c0/8b0079f714f3a075365644f2e83cd07536e99b5e00de60aa1a28f260f0683be70d83fb556425aa6ebd2ea528a607d6bf2b4983b3c11569342314d92840fb411e
+  checksum: 10c0/865409910077363225173f78d9495dd184dae40414f7e34d2f13408138f8ae7432e715e98d2dc717a52e73e224134fbf7c7a7f53267fc891952611ccda7c9242
   languageName: node
   linkType: hard
 
@@ -9112,13 +9052,6 @@ __metadata:
   version: 10.1.0
   resolution: "ip-address@npm:10.1.0"
   checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
-  languageName: node
-  linkType: hard
-
-"ip-regex@npm:5.0.0":
-  version: 5.0.0
-  resolution: "ip-regex@npm:5.0.0"
-  checksum: 10c0/23f07cf393436627b3a91f7121eee5bc831522d07c95ddd13f5a6f7757698b08551480f12e5dbb3bf248724da135d54405c9687733dba7314f74efae593bdf06
   languageName: node
   linkType: hard
 
@@ -9196,16 +9129,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-cidr@npm:^6.0.1":
-  version: 6.0.2
-  resolution: "is-cidr@npm:6.0.2"
+"is-cidr@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "is-cidr@npm:6.0.3"
   dependencies:
     cidr-regex: "npm:^5.0.1"
-  checksum: 10c0/0e7be58ff5674661f130a5f0ff3b853f6f37d2eb4f975a8642f6b999e5a2eade621282014d9be510f624b1417b6004093ba52c009952452cdb4b0d1c3eb2095c
+  checksum: 10c0/84f3253e9223767b2d560bc6080c9d186c076eab46066bc01dfd987b811f76fde32ed6597c90008170aa9ca3594f02018cc5b29d2572cea6294c0c769414ed9f
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1, is-core-module@npm:^2.5.0":
+"is-core-module@npm:^2.16.1, is-core-module@npm:^2.5.0":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -9604,11 +9537,11 @@ __metadata:
   linkType: hard
 
 "is-wsl@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "is-wsl@npm:3.1.0"
+  version: 3.1.1
+  resolution: "is-wsl@npm:3.1.1"
   dependencies:
     is-inside-container: "npm:^1.0.0"
-  checksum: 10c0/d3317c11995690a32c362100225e22ba793678fe8732660c6de511ae71a0ff05b06980cf21f98a6bf40d7be0e9e9506f859abe00a1118287d63e53d0a3d06947
+  checksum: 10c0/7e5023522bfb8f27de4de960b0d82c4a8146c0bddb186529a3616d78b5bbbfc19ef0c5fc60d0b3a3cc0bf95a415fbdedc18454310ea3049587c879b07ace5107
   languageName: node
   linkType: hard
 
@@ -9633,10 +9566,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isexe@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "isexe@npm:3.1.1"
-  checksum: 10c0/9ec257654093443eb0a528a9c8cbba9c0ca7616ccb40abd6dde7202734d96bb86e4ac0d764f0f8cd965856aacbff2f4ce23e730dc19dfb41e3b0d865ca6fdcc7
+"isexe@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "isexe@npm:4.0.0"
+  checksum: 10c0/5884815115bceac452877659a9c7726382531592f43dc29e5d48b7c4100661aed54018cb90bd36cb2eaeba521092570769167acbb95c18d39afdccbcca06c5ce
   languageName: node
   linkType: hard
 
@@ -9725,7 +9658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iterator.prototype@npm:^1.1.4":
+"iterator.prototype@npm:^1.1.5":
   version: 1.1.5
   resolution: "iterator.prototype@npm:1.1.5"
   dependencies:
@@ -10349,6 +10282,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-with-bigint@npm:^3.5.3":
+  version: 3.5.8
+  resolution: "json-with-bigint@npm:3.5.8"
+  checksum: 10c0/a0c4e37626d74a9a493539f9f9a94855933fa15ea2f028859a787229a42c5f11803db6f94f1ce7b1d89756c1e80a7c1f11006bac266ec7ce819b75701765ca0a
+  languageName: node
+  linkType: hard
+
 "json5@npm:^2.2.1, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
@@ -10470,11 +10410,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libnpmdiff@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "libnpmdiff@npm:8.1.0"
+"libnpmdiff@npm:^8.1.5":
+  version: 8.1.5
+  resolution: "libnpmdiff@npm:8.1.5"
   dependencies:
-    "@npmcli/arborist": "npm:^9.2.0"
+    "@npmcli/arborist": "npm:^9.4.2"
     "@npmcli/installed-package-contents": "npm:^4.0.0"
     binary-extensions: "npm:^3.0.0"
     diff: "npm:^8.0.2"
@@ -10482,36 +10422,36 @@ __metadata:
     npm-package-arg: "npm:^13.0.0"
     pacote: "npm:^21.0.2"
     tar: "npm:^7.5.1"
-  checksum: 10c0/0ddac7be7ee0e41843d9908def6a975460484f0629a8f83e4f93e5803f8d5d7f191cecd691da471f578bcdf66a0a6e2699ca1de9e8c98b6240e6bcbeabf2a566
+  checksum: 10c0/4bc5fb7baeee9ea662a712591c6c0d3f946ef9ab5e388c15a0f56738cfcf3bc871b4a5509803138e0c58a16334171d3ab015bcff01e6f3d5b81f62ae92f7baef
   languageName: node
   linkType: hard
 
-"libnpmexec@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "libnpmexec@npm:10.2.0"
+"libnpmexec@npm:^10.2.5":
+  version: 10.2.5
+  resolution: "libnpmexec@npm:10.2.5"
   dependencies:
-    "@npmcli/arborist": "npm:^9.2.0"
+    "@gar/promise-retry": "npm:^1.0.0"
+    "@npmcli/arborist": "npm:^9.4.2"
     "@npmcli/package-json": "npm:^7.0.0"
     "@npmcli/run-script": "npm:^10.0.0"
     ci-info: "npm:^4.0.0"
     npm-package-arg: "npm:^13.0.0"
     pacote: "npm:^21.0.2"
     proc-log: "npm:^6.0.0"
-    promise-retry: "npm:^2.0.1"
     read: "npm:^5.0.1"
     semver: "npm:^7.3.7"
     signal-exit: "npm:^4.1.0"
     walk-up-path: "npm:^4.0.0"
-  checksum: 10c0/3cb41724f25d2093d79f07505c4fd08436861c259fb2a07f175a8f9910d379e2b5c17162415c7a5cc7fa00b0d3788d35d7dae33ea853f86ec056d0db7dea67d2
+  checksum: 10c0/609df6ee8b7a44a8701ce22b94403aa72966731888836bb910bec22e5b47a66fa9168f71609b72cb80641a34ef2f7a34277c1143270b03e3fa2ff4ed75d1ef54
   languageName: node
   linkType: hard
 
-"libnpmfund@npm:^7.0.14":
-  version: 7.0.14
-  resolution: "libnpmfund@npm:7.0.14"
+"libnpmfund@npm:^7.0.19":
+  version: 7.0.19
+  resolution: "libnpmfund@npm:7.0.19"
   dependencies:
-    "@npmcli/arborist": "npm:^9.2.0"
-  checksum: 10c0/d4ab75ea3f64ac3c0c5564183b3d1f5b5368221d518fca417cc91383a925e287c70fecfa9d6838fc586ce17a128639ee5c30c598aef669765c1ba524d1d4764a
+    "@npmcli/arborist": "npm:^9.4.2"
+  checksum: 10c0/343801f0799f7af7f94e0d805459313a1a3c1c7732938fc19f4d4f9eecff75b1a7afe17ab2854e81d3e9efd583bcb216fe6eacff0809473d3813a30393550273
   languageName: node
   linkType: hard
 
@@ -10525,15 +10465,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libnpmpack@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "libnpmpack@npm:9.1.0"
+"libnpmpack@npm:^9.1.5":
+  version: 9.1.5
+  resolution: "libnpmpack@npm:9.1.5"
   dependencies:
-    "@npmcli/arborist": "npm:^9.2.0"
+    "@npmcli/arborist": "npm:^9.4.2"
     "@npmcli/run-script": "npm:^10.0.0"
     npm-package-arg: "npm:^13.0.0"
     pacote: "npm:^21.0.2"
-  checksum: 10c0/13fb929cc6c04e22ae2943ef2625c163f886fdfd2c96498e13a8f11bd6491f6f2cde2e1f74513796a37af362a6f56b2366817f3c1ad144eef7a3999c2ccefdd3
+  checksum: 10c0/577d56f7b62b96ca75c28cbb78b65aff12369494a1be335b5b47b276bfcc1224ddb40fa15834ff7baa81cbfd88620a83ebcefdc68e9d87d0fe855f107a1a9b85
   languageName: node
   linkType: hard
 
@@ -10935,9 +10875,9 @@ __metadata:
   linkType: hard
 
 "lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
-  version: 11.2.4
-  resolution: "lru-cache@npm:11.2.4"
-  checksum: 10c0/4a24f9b17537619f9144d7b8e42cd5a225efdfd7076ebe7b5e7dc02b860a818455201e67fbf000765233fe7e339d3c8229fc815e9b58ee6ede511e07608c19b2
+  version: 11.2.7
+  resolution: "lru-cache@npm:11.2.7"
+  checksum: 10c0/549cdb59488baa617135fc12159cafb1a97f91079f35093bb3bcad72e849fc64ace636d244212c181dfdf1a99bbfa90757ff303f98561958ee4d0f885d9bd5f7
   languageName: node
   linkType: hard
 
@@ -10974,13 +10914,13 @@ __metadata:
   linkType: hard
 
 "make-asynchronous@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "make-asynchronous@npm:1.0.1"
+  version: 1.1.0
+  resolution: "make-asynchronous@npm:1.1.0"
   dependencies:
     p-event: "npm:^6.0.0"
     type-fest: "npm:^4.6.0"
-    web-worker: "npm:1.2.0"
-  checksum: 10c0/fbf6a04c89b4e6eca4ee458d33eb51474a97da19e197825dd15becbc191bd2cbc8a0c9eee3f116d52954af421e42d922deeb53ac4be9ac349307677fd149e66a
+    web-worker: "npm:^1.5.0"
+  checksum: 10c0/794c4876839f00bc6e287a1f07177dc3bb5c177d06d4ebe9e3a055758d9740b9b296a957c9015bed8d0d92d70035c70108e4c7d7bc2880fb16b94d0bd4b75a37
   languageName: node
   linkType: hard
 
@@ -11010,11 +10950,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^15.0.0, make-fetch-happen@npm:^15.0.1, make-fetch-happen@npm:^15.0.3":
-  version: 15.0.3
-  resolution: "make-fetch-happen@npm:15.0.3"
+"make-fetch-happen@npm:^15.0.0, make-fetch-happen@npm:^15.0.1, make-fetch-happen@npm:^15.0.4, make-fetch-happen@npm:^15.0.5":
+  version: 15.0.5
+  resolution: "make-fetch-happen@npm:15.0.5"
   dependencies:
+    "@gar/promise-retry": "npm:^1.0.0"
     "@npmcli/agent": "npm:^4.0.0"
+    "@npmcli/redact": "npm:^4.0.0"
     cacache: "npm:^20.0.1"
     http-cache-semantics: "npm:^4.1.1"
     minipass: "npm:^7.0.2"
@@ -11023,9 +10965,8 @@ __metadata:
     minipass-pipeline: "npm:^1.2.4"
     negotiator: "npm:^1.0.0"
     proc-log: "npm:^6.0.0"
-    promise-retry: "npm:^2.0.1"
     ssri: "npm:^13.0.0"
-  checksum: 10c0/525f74915660be60b616bcbd267c4a5b59481b073ba125e45c9c3a041bb1a47a2bd0ae79d028eb6f5f95bf9851a4158423f5068539c3093621abb64027e8e461
+  checksum: 10c0/527580eb5e5476e6ad07a4e3bd017d13e935f4be815674b442081ae5a721c13d3af5715006619e6be79a85723067e047f83a0c9e699f41d8cec43609a8de4f7b
   languageName: node
   linkType: hard
 
@@ -11698,12 +11639,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.3, minimatch@npm:^10.1.1":
-  version: 10.1.2
-  resolution: "minimatch@npm:10.1.2"
+"minimatch@npm:^10.0.3, minimatch@npm:^10.1.1, minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
+  version: 10.2.4
+  resolution: "minimatch@npm:10.2.4"
   dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.1"
-  checksum: 10c0/0cccef3622201703de6ecf9d772c0be1d5513dcc038ed9feb866c20cf798243e678ac35605dac3f1a054650c28037486713fe9e9a34b184b9097959114daf086
+    brace-expansion: "npm:^5.0.2"
+  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
   languageName: node
   linkType: hard
 
@@ -11717,11 +11658,11 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^9.0.0, minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -11753,17 +11694,17 @@ __metadata:
   linkType: hard
 
 "minipass-fetch@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "minipass-fetch@npm:5.0.0"
+  version: 5.0.2
+  resolution: "minipass-fetch@npm:5.0.2"
   dependencies:
-    encoding: "npm:^0.1.13"
+    iconv-lite: "npm:^0.7.2"
     minipass: "npm:^7.0.3"
-    minipass-sized: "npm:^1.0.3"
+    minipass-sized: "npm:^2.0.0"
     minizlib: "npm:^3.0.1"
   dependenciesMeta:
-    encoding:
+    iconv-lite:
       optional: true
-  checksum: 10c0/9443aab5feab190972f84b64116e54e58dd87a58e62399cae0a4a7461b80568281039b7c3a38ba96453431ebc799d1e26999e548540156216729a4967cd5ef06
+  checksum: 10c0/ce4ab9f21cfabaead2097d95dd33f485af8072fbc6b19611bce694965393453a1639d641c2bcf1c48f2ea7d41ea7fab8278373f1d0bee4e63b0a5b2cdd0ef649
   languageName: node
   linkType: hard
 
@@ -11785,12 +11726,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-sized@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "minipass-sized@npm:1.0.3"
+"minipass-sized@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "minipass-sized@npm:2.0.0"
   dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10c0/298f124753efdc745cfe0f2bdfdd81ba25b9f4e753ca4a2066eb17c821f25d48acea607dfc997633ee5bf7b6dfffb4eee4f2051eb168663f0b99fad2fa4829cb
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/f9201696a6f6d68610d04c9c83e3d2e5cb9c026aae1c8cbf7e17f386105cb79c1bb088dbc21bf0b1eb4f3fb5df384fd1e7aa3bf1f33868c416ae8c8a92679db8
   languageName: node
   linkType: hard
 
@@ -11803,10 +11744,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.1, minipass@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "minipass@npm:7.1.2"
-  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
   languageName: node
   linkType: hard
 
@@ -11960,6 +11901,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-exports-info@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "node-exports-info@npm:1.6.0"
+  dependencies:
+    array.prototype.flatmap: "npm:^1.3.3"
+    es-errors: "npm:^1.3.0"
+    object.entries: "npm:^1.1.9"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/3613f21c60b047e66f168d3499a6be0060d89fb01ddceaa7032c2fb318aff12e4b9b111449c1a9aeb3b848bfdc1d4b6bc8fab327af692319597d21a1e7063692
+  languageName: node
+  linkType: hard
+
 "node-fetch-native@npm:^1.6.6":
   version: 1.6.7
   resolution: "node-fetch-native@npm:1.6.7"
@@ -11988,7 +11941,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^12.1.0, node-gyp@npm:^12.2.0":
+"node-gyp@npm:^12.1.0, node-gyp@npm:^12.2.0, node-gyp@npm:latest":
   version: 12.2.0
   resolution: "node-gyp@npm:12.2.0"
   dependencies:
@@ -12008,26 +11961,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:latest":
-  version: 12.1.0
-  resolution: "node-gyp@npm:12.1.0"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^15.0.0"
-    nopt: "npm:^9.0.0"
-    proc-log: "npm:^6.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.5.2"
-    tinyglobby: "npm:^0.2.12"
-    which: "npm:^6.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10c0/f43efea8aaf0beb6b2f6184e533edad779b2ae38062953e21951f46221dd104006cc574154f2ad4a135467a5aae92c49e84ef289311a82e08481c5df0e8dc495
-  languageName: node
-  linkType: hard
-
 "node-int64@npm:^0.4.0":
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
@@ -12036,9 +11969,9 @@ __metadata:
   linkType: hard
 
 "node-releases@npm:^2.0.27":
-  version: 2.0.27
-  resolution: "node-releases@npm:2.0.27"
-  checksum: 10c0/f1e6583b7833ea81880627748d28a3a7ff5703d5409328c216ae57befbced10ce2c991bea86434e8ec39003bd017f70481e2e5f8c1f7e0a7663241f81d6e00e2
+  version: 2.0.36
+  resolution: "node-releases@npm:2.0.36"
+  checksum: 10c0/85d8d7f4b6248c8372831cbcc3829ce634cb2b01dbd85e55705cefc8a9eda4ce8121bd218b9629cf2579aef8a360541bad409f3925a35675c825b9471a49d7e9
   languageName: node
   linkType: hard
 
@@ -12105,10 +12038,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^8.0.0":
-  version: 8.1.0
-  resolution: "normalize-url@npm:8.1.0"
-  checksum: 10c0/e9b68db5f0264ce74fc083e2120b4a40fb3248e5dceec5f795bddcee0311b3613f858c9a65f258614fac2776b8e9957023bea8fe7299db1496b3cd1c75976cfe
+"normalize-url@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "normalize-url@npm:9.0.0"
+  checksum: 10c0/ff8271b26b808dc4c9caf309e1f5f0dcf75e4e05c5c09f3ee3c9dde2bda7f761df1b4c9458758c1919e3420a71c464da8026c1a9a11dedff99c056f3efd6afbc
   languageName: node
   linkType: hard
 
@@ -12169,12 +12102,12 @@ __metadata:
   linkType: hard
 
 "npm-packlist@npm:^10.0.1":
-  version: 10.0.3
-  resolution: "npm-packlist@npm:10.0.3"
+  version: 10.0.4
+  resolution: "npm-packlist@npm:10.0.4"
   dependencies:
     ignore-walk: "npm:^8.0.0"
     proc-log: "npm:^6.0.0"
-  checksum: 10c0/f4fa58890e7d9e80299c284cdf65fafac6eae0c23b830bbae9953255571364897a6f22a02b5da63f0c43e45019d7446feec6ed79124edc6a44c8d6c9a19d25cf
+  checksum: 10c0/500ec00ed5edc3f7136255a8c17dfd36fb718182af61a86a68768aa3b325f69739953fe8888fa8e4765db00e7892a9d0a30093b145d091b23e96b7d1bbf1187e
   languageName: node
   linkType: hard
 
@@ -12252,48 +12185,47 @@ __metadata:
   linkType: hard
 
 "npm@npm:^11.6.2":
-  version: 11.9.0
-  resolution: "npm@npm:11.9.0"
+  version: 11.12.0
+  resolution: "npm@npm:11.12.0"
   dependencies:
     "@isaacs/string-locale-compare": "npm:^1.1.0"
-    "@npmcli/arborist": "npm:^9.2.0"
-    "@npmcli/config": "npm:^10.6.0"
+    "@npmcli/arborist": "npm:^9.4.2"
+    "@npmcli/config": "npm:^10.8.0"
     "@npmcli/fs": "npm:^5.0.0"
     "@npmcli/map-workspaces": "npm:^5.0.3"
     "@npmcli/metavuln-calculator": "npm:^9.0.3"
-    "@npmcli/package-json": "npm:^7.0.4"
+    "@npmcli/package-json": "npm:^7.0.5"
     "@npmcli/promise-spawn": "npm:^9.0.1"
     "@npmcli/redact": "npm:^4.0.0"
-    "@npmcli/run-script": "npm:^10.0.3"
-    "@sigstore/tuf": "npm:^4.0.1"
+    "@npmcli/run-script": "npm:^10.0.4"
+    "@sigstore/tuf": "npm:^4.0.2"
     abbrev: "npm:^4.0.0"
     archy: "npm:~1.0.0"
-    cacache: "npm:^20.0.3"
+    cacache: "npm:^20.0.4"
     chalk: "npm:^5.6.2"
     ci-info: "npm:^4.4.0"
-    cli-columns: "npm:^4.0.0"
     fastest-levenshtein: "npm:^1.0.16"
     fs-minipass: "npm:^3.0.3"
-    glob: "npm:^13.0.0"
+    glob: "npm:^13.0.6"
     graceful-fs: "npm:^4.2.11"
     hosted-git-info: "npm:^9.0.2"
     ini: "npm:^6.0.0"
-    init-package-json: "npm:^8.2.4"
-    is-cidr: "npm:^6.0.1"
+    init-package-json: "npm:^8.2.5"
+    is-cidr: "npm:^6.0.3"
     json-parse-even-better-errors: "npm:^5.0.0"
     libnpmaccess: "npm:^10.0.3"
-    libnpmdiff: "npm:^8.1.0"
-    libnpmexec: "npm:^10.2.0"
-    libnpmfund: "npm:^7.0.14"
+    libnpmdiff: "npm:^8.1.5"
+    libnpmexec: "npm:^10.2.5"
+    libnpmfund: "npm:^7.0.19"
     libnpmorg: "npm:^8.0.1"
-    libnpmpack: "npm:^9.1.0"
+    libnpmpack: "npm:^9.1.5"
     libnpmpublish: "npm:^11.1.3"
     libnpmsearch: "npm:^9.0.1"
     libnpmteam: "npm:^8.0.2"
     libnpmversion: "npm:^8.0.3"
-    make-fetch-happen: "npm:^15.0.3"
-    minimatch: "npm:^10.1.1"
-    minipass: "npm:^7.1.1"
+    make-fetch-happen: "npm:^15.0.5"
+    minimatch: "npm:^10.2.4"
+    minipass: "npm:^7.1.3"
     minipass-pipeline: "npm:^1.2.4"
     ms: "npm:^2.1.2"
     node-gyp: "npm:^12.2.0"
@@ -12306,25 +12238,25 @@ __metadata:
     npm-registry-fetch: "npm:^19.1.1"
     npm-user-validate: "npm:^4.0.0"
     p-map: "npm:^7.0.4"
-    pacote: "npm:^21.1.0"
+    pacote: "npm:^21.5.0"
     parse-conflict-json: "npm:^5.0.1"
     proc-log: "npm:^6.1.0"
     qrcode-terminal: "npm:^0.12.0"
     read: "npm:^5.0.1"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.7.4"
     spdx-expression-parse: "npm:^4.0.0"
-    ssri: "npm:^13.0.0"
+    ssri: "npm:^13.0.1"
     supports-color: "npm:^10.2.2"
-    tar: "npm:^7.5.7"
+    tar: "npm:^7.5.11"
     text-table: "npm:~0.2.0"
     tiny-relative-date: "npm:^2.0.2"
     treeverse: "npm:^3.0.0"
     validate-npm-package-name: "npm:^7.0.2"
-    which: "npm:^6.0.0"
+    which: "npm:^6.0.1"
   bin:
     npm: bin/npm-cli.js
     npx: bin/npx-cli.js
-  checksum: 10c0/7d1c16680fc8689c7c4e1e25b87be204a1058a1737f6d40b0e52019e1c415d754af9ccb1ac897301635c70186653109bb0130c319de2ebb17bbda4fce3a79551
+  checksum: 10c0/76410f053e80336e4a927904ae5dfe40dc1df75781e51a8e90d1ca65fcc8a19b01d55ede186a03ab0efed0c8daf106dd51036811ea897cbb716a593f74715905
   languageName: node
   linkType: hard
 
@@ -12444,21 +12376,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1":
-  version: 2.4.1
-  resolution: "on-finished@npm:2.4.1"
-  dependencies:
-    ee-first: "npm:1.1.1"
-  checksum: 10c0/46fb11b9063782f2d9968863d9cbba33d77aa13c17f895f56129c274318b86500b22af3a160fe9995aa41317efcd22941b6eba747f718ced08d9a73afdb087b4
-  languageName: node
-  linkType: hard
-
 "on-finished@npm:~2.3.0":
   version: 2.3.0
   resolution: "on-finished@npm:2.3.0"
   dependencies:
     ee-first: "npm:1.1.1"
   checksum: 10c0/c904f9e518b11941eb60279a3cbfaf1289bd0001f600a950255b1dede9fe3df8cd74f38483550b3bb9485165166acb5db500c3b4c4337aec2815c88c96fcc2ea
+  languageName: node
+  linkType: hard
+
+"on-finished@npm:~2.4.1":
+  version: 2.4.1
+  resolution: "on-finished@npm:2.4.1"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: 10c0/46fb11b9063782f2d9968863d9cbba33d77aa13c17f895f56129c274318b86500b22af3a160fe9995aa41317efcd22941b6eba747f718ced08d9a73afdb087b4
   languageName: node
   linkType: hard
 
@@ -12819,10 +12751,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pacote@npm:^21.0.0, pacote@npm:^21.0.2, pacote@npm:^21.1.0":
-  version: 21.2.0
-  resolution: "pacote@npm:21.2.0"
+"pacote@npm:^21.0.0, pacote@npm:^21.0.2, pacote@npm:^21.5.0":
+  version: 21.5.0
+  resolution: "pacote@npm:21.5.0"
   dependencies:
+    "@gar/promise-retry": "npm:^1.0.0"
     "@npmcli/git": "npm:^7.0.0"
     "@npmcli/installed-package-contents": "npm:^4.0.0"
     "@npmcli/package-json": "npm:^7.0.0"
@@ -12836,13 +12769,12 @@ __metadata:
     npm-pick-manifest: "npm:^11.0.1"
     npm-registry-fetch: "npm:^19.0.0"
     proc-log: "npm:^6.0.0"
-    promise-retry: "npm:^2.0.1"
     sigstore: "npm:^4.0.0"
     ssri: "npm:^13.0.0"
     tar: "npm:^7.4.3"
   bin:
     pacote: bin/index.js
-  checksum: 10c0/c9d5855dff6901a728908d5d34757d73d13c2ef098945328a0a86466857fd73c59099c5e2bcb2dac92d594ea4faabb4c22de422b2ad46e9aa5e5d3ed66074b9e
+  checksum: 10c0/f91ee9c3645300b52eebdce461d4e1d8a9311e9ddf7f55f87532cd3df0282379613b0a9703f97d81c9efaae382f08fcf29e359d7f47f0e9c9670cfb7fc472954
   languageName: node
   linkType: hard
 
@@ -13023,13 +12955,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "path-scurry@npm:2.0.1"
+"path-scurry@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "path-scurry@npm:2.0.2"
   dependencies:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
-  checksum: 10c0/2a16ed0e81fbc43513e245aa5763354e25e787dab0d539581a6c3f0f967461a159ed6236b2559de23aa5b88e7dc32b469b6c47568833dd142a4b24b4f5cd2620
+  checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
   languageName: node
   linkType: hard
 
@@ -13203,11 +13135,11 @@ __metadata:
   linkType: hard
 
 "prettier-linter-helpers@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "prettier-linter-helpers@npm:1.0.0"
+  version: 1.0.1
+  resolution: "prettier-linter-helpers@npm:1.0.1"
   dependencies:
     fast-diff: "npm:^1.1.2"
-  checksum: 10c0/81e0027d731b7b3697ccd2129470ed9913ecb111e4ec175a12f0fcfab0096516373bf0af2fef132af50cafb0a905b74ff57996d615f59512bb9ac7378fcc64ab
+  checksum: 10c0/91cea965681bc5f62c9d26bd3ca6358b81557261d4802e96ec1cf0acbd99d4b61632d53320cd2c3ec7d7f7805a81345644108a41ef46ddc9688e783a9ac792d1
   languageName: node
   linkType: hard
 
@@ -13293,16 +13225,6 @@ __metadata:
   version: 3.0.2
   resolution: "promise-call-limit@npm:3.0.2"
   checksum: 10c0/1f984c16025925594d738833f5da7525b755f825a198d5a0cac1c0280b4f38ecc3c32c1f4e5ef614ddcfd6718c1a8c3f98a3290ae6f421342281c9a88c488bf7
-  languageName: node
-  linkType: hard
-
-"promise-retry@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "promise-retry@npm:2.0.1"
-  dependencies:
-    err-code: "npm:^2.0.2"
-    retry: "npm:^0.12.0"
-  checksum: 10c0/9c7045a1a2928094b5b9b15336dcd2a7b1c052f674550df63cc3f36cd44028e5080448175b6f6ca32b642de81150f5e7b1a98b728f15cb069f2dd60ac2616b96
   languageName: node
   linkType: hard
 
@@ -13392,12 +13314,12 @@ __metadata:
   linkType: hard
 
 "pump@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "pump@npm:3.0.3"
+  version: 3.0.4
+  resolution: "pump@npm:3.0.4"
   dependencies:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
-  checksum: 10c0/ada5cdf1d813065bbc99aa2c393b8f6beee73b5de2890a8754c9f488d7323ffd2ca5f5a0943b48934e3fcbd97637d0337369c3c631aeb9614915db629f1c75c9
+  checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
   languageName: node
   linkType: hard
 
@@ -13544,8 +13466,8 @@ __metadata:
   linkType: hard
 
 "react-native-builder-bob@npm:^0.40.17":
-  version: 0.40.17
-  resolution: "react-native-builder-bob@npm:0.40.17"
+  version: 0.40.18
+  resolution: "react-native-builder-bob@npm:0.40.18"
   dependencies:
     "@babel/core": "npm:^7.25.2"
     "@babel/plugin-transform-flow-strip-types": "npm:^7.26.5"
@@ -13566,12 +13488,12 @@ __metadata:
     json5: "npm:^2.2.1"
     kleur: "npm:^4.1.4"
     prompts: "npm:^2.4.2"
-    react-native-monorepo-config: "npm:^0.3.1"
+    react-native-monorepo-config: "npm:^0.3.3"
     which: "npm:^2.0.2"
     yargs: "npm:^17.5.1"
   bin:
     bob: bin/bob
-  checksum: 10c0/b3bb6f907a181ea0473cbf68cbc9f594eb5f2adc885011f4d29c961258d5f123494c28565881c0190f9f1a297b11aad7a1238742dd88345b0390e4343d9c2c11
+  checksum: 10c0/5f1c969d339ece33208faebbf7022c1db3ec127ab91a0f21a29e0d7cbd18dfa702586fa1169f9dd642fbceeb2733af4651143d50010effb8bb150a9bfd4cc4ff
   languageName: node
   linkType: hard
 
@@ -13586,8 +13508,8 @@ __metadata:
   linkType: hard
 
 "react-native-gesture-handler@npm:^2.26.0":
-  version: 2.29.1
-  resolution: "react-native-gesture-handler@npm:2.29.1"
+  version: 2.30.0
+  resolution: "react-native-gesture-handler@npm:2.30.0"
   dependencies:
     "@egjs/hammerjs": "npm:^2.0.17"
     hoist-non-react-statics: "npm:^3.3.0"
@@ -13595,7 +13517,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/63de75098fb5733a4a24d3359c307ee2295939c48dc0808cf0efd6a50948834370e6b32a165b908fcbd7bc186e7bb4db3afbcd66b3fde3cbccca6f6b47f1b400
+  checksum: 10c0/26b94b0f97433fc6fb5b1c196ef29fce4f5a66c77fabb1bc33db91099357fbd44a5220783fcbb91d42700bcd578f2fd114314029d9e0d4674878767d9b7f5df6
   languageName: node
   linkType: hard
 
@@ -13610,22 +13532,22 @@ __metadata:
   linkType: hard
 
 "react-native-is-edge-to-edge@npm:^1.1.6, react-native-is-edge-to-edge@npm:^1.1.7":
-  version: 1.2.1
-  resolution: "react-native-is-edge-to-edge@npm:1.2.1"
+  version: 1.3.1
+  resolution: "react-native-is-edge-to-edge@npm:1.3.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/87d20b900aded7d44c90afb946a7aa03c23a94ca3dd547bdddc2303b85357e4aab22567a57b19f1558d6c8be7058e3dcf34faa1e15182d1604f90974266d9a1d
+  checksum: 10c0/28cebd5f1f3632864ff5e342278721d1e5e38627ae73859a8814012116ef15c629fee7137a6c9c97bb05d94bbe639b0b47e69b36fc2735ab53ed31570140663f
   languageName: node
   linkType: hard
 
-"react-native-monorepo-config@npm:^0.3.1":
-  version: 0.3.2
-  resolution: "react-native-monorepo-config@npm:0.3.2"
+"react-native-monorepo-config@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "react-native-monorepo-config@npm:0.3.3"
   dependencies:
     escape-string-regexp: "npm:^5.0.0"
     fast-glob: "npm:^3.3.3"
-  checksum: 10c0/c711f6a898ae263b68aef3bf8bd9c3806cd489676da8c5480dd155859b47bcd49a7700f3c056896c19b3ce2c2c3ea42a5482def93b0ff03febbe023ceb128c96
+  checksum: 10c0/42dd8de1bb976c794fe1124ab08fba4645f189c7bdbdcd24dc0e05b639591e690891f89e5dba33c57691840365af85b48004c29c1c128ff195a95e766bb9752e
   languageName: node
   linkType: hard
 
@@ -13654,12 +13576,12 @@ __metadata:
   linkType: hard
 
 "react-native-safe-area-context@npm:^5.4.1":
-  version: 5.6.2
-  resolution: "react-native-safe-area-context@npm:5.6.2"
+  version: 5.7.0
+  resolution: "react-native-safe-area-context@npm:5.7.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/3c8df21a1dbac83116b9c9bd5d20b7c1bb7649ecef44a111af6fb6b237241f5f4d692189eec30a69f5701b857249257da3621b9e17165460a2bb71faac7b92ae
+  checksum: 10c0/c3799e17321b41df1e0a10492c98472f8f8225ef0bbaf8146c4a9acb9519aae9ac11429059143c215e4402c2808e8445274850a339f8477522ded2461e18da80
   languageName: node
   linkType: hard
 
@@ -13970,15 +13892,15 @@ __metadata:
   linkType: hard
 
 "read-pkg@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "read-pkg@npm:10.0.0"
+  version: 10.1.0
+  resolution: "read-pkg@npm:10.1.0"
   dependencies:
     "@types/normalize-package-data": "npm:^2.4.4"
     normalize-package-data: "npm:^8.0.0"
     parse-json: "npm:^8.3.0"
-    type-fest: "npm:^5.2.0"
-    unicorn-magic: "npm:^0.3.0"
-  checksum: 10c0/d1f0a0db671a408f0ee03998e42217370e221b916903b36750470793c9a9db085b2da79bba85c7a51556003972fd770f838480ac80763ea7ab3d6db1faad8011
+    type-fest: "npm:^5.4.4"
+    unicorn-magic: "npm:^0.4.0"
+  checksum: 10c0/6a284bd00945239f715b8a0e986ad0faf29e184f5f26890734991c2696e48b4fa330939f937faac85bc4a2f6be17f8fce288ecd795b337bb4e37a5b75c464569
   languageName: node
   linkType: hard
 
@@ -14171,11 +14093,11 @@ __metadata:
   linkType: hard
 
 "registry-auth-token@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "registry-auth-token@npm:5.1.0"
+  version: 5.1.1
+  resolution: "registry-auth-token@npm:5.1.1"
   dependencies:
-    "@pnpm/npm-conf": "npm:^2.1.0"
-  checksum: 10c0/316229bd8a4acc29a362a7a3862ff809e608256f0fd9e0b133412b43d6a9ea18743756a0ec5ee1467a5384e1023602b85461b3d88d1336b11879e42f7cf02c12
+    "@pnpm/npm-conf": "npm:^3.0.2"
+  checksum: 10c0/86b0f7fd87d327cb4177fee69bcf96563147ea72e206bc9c7a6a50a51c785a31b83a6c45956a489ed292d23b908b2755a075d0b2f7fec1ba91b1fb800b24cee3
   languageName: node
   linkType: hard
 
@@ -14286,9 +14208,9 @@ __metadata:
   linkType: hard
 
 "resolve-workspace-root@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "resolve-workspace-root@npm:2.0.0"
-  checksum: 10c0/658e6fbc199c51f4903867ab371f03122d9865b4fb4fd3a2069c39b429132d91535e5112f5c6c561fa0852cb8393505b7f94b58c3e2566bab610a48172f38e3f
+  version: 2.0.1
+  resolution: "resolve-workspace-root@npm:2.0.1"
+  checksum: 10c0/83104ea8476ba451a4bac32db42cf1dc79a7b98810764e507830a2f63af20cfb00fe7da5b0c324d77d4fcfda7a24e9e17895690d6f6a498735b633fd7fc372ca
   languageName: node
   linkType: hard
 
@@ -14299,7 +14221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.2":
+"resolve@npm:^1.20.0, resolve@npm:^1.22.11, resolve@npm:^1.22.2":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
   dependencies:
@@ -14313,15 +14235,18 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^2.0.0-next.5":
-  version: 2.0.0-next.5
-  resolution: "resolve@npm:2.0.0-next.5"
+  version: 2.0.0-next.6
+  resolution: "resolve@npm:2.0.0-next.6"
   dependencies:
-    is-core-module: "npm:^2.13.0"
+    es-errors: "npm:^1.3.0"
+    is-core-module: "npm:^2.16.1"
+    node-exports-info: "npm:^1.6.0"
+    object-keys: "npm:^1.1.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/a6c33555e3482ea2ec4c6e3d3bf0d78128abf69dca99ae468e64f1e30acaa318fd267fb66c8836b04d558d3e2d6ed875fe388067e7d8e0de647d3c21af21c43a
+  checksum: 10c0/4e44cb84aa9a3c7c82d4a98e8111879671150496160a53ca6cdbed6101bf239f19105f8b8b84e40c0b76d46b0d9626813510b19a80e01f4ae18692e9d0b47749
   languageName: node
   linkType: hard
 
@@ -14334,7 +14259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.11#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>":
   version: 1.22.11
   resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
@@ -14348,15 +14273,18 @@ __metadata:
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^2.0.0-next.5#optional!builtin<compat/resolve>":
-  version: 2.0.0-next.5
-  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.5#optional!builtin<compat/resolve>::version=2.0.0-next.5&hash=c3c19d"
+  version: 2.0.0-next.6
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.6#optional!builtin<compat/resolve>::version=2.0.0-next.6&hash=c3c19d"
   dependencies:
-    is-core-module: "npm:^2.13.0"
+    es-errors: "npm:^1.3.0"
+    is-core-module: "npm:^2.16.1"
+    node-exports-info: "npm:^1.6.0"
+    object-keys: "npm:^1.1.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/78ad6edb8309a2bfb720c2c1898f7907a37f858866ce11a5974643af1203a6a6e05b2fa9c53d8064a673a447b83d42569260c306d43628bff5bb101969708355
+  checksum: 10c0/dca533e38820b0d8d636f269824cef3b7435802ab7401211c6f10af03be0e2f7e216047234e1623046c0a6791577079767e0c04f0d36e42c7f567b1bff7b0742
   languageName: node
   linkType: hard
 
@@ -14393,13 +14321,6 @@ __metadata:
   version: 0.13.1
   resolution: "retry@npm:0.13.1"
   checksum: 10c0/9ae822ee19db2163497e074ea919780b1efa00431d197c7afdb950e42bf109196774b92a49fc9821f0b8b328a98eea6017410bfc5e8a0fc19c85c6d11adb3772
-  languageName: node
-  linkType: hard
-
-"retry@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "retry@npm:0.12.0"
-  checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
   languageName: node
   linkType: hard
 
@@ -14509,9 +14430,9 @@ __metadata:
   linkType: hard
 
 "sax@npm:>=0.6.0":
-  version: 1.4.3
-  resolution: "sax@npm:1.4.3"
-  checksum: 10c0/45bba07561d93f184a8686e1a543418ced8c844b994fbe45cc49d5cd2fc8ac7ec949dae38565e35e388ad0cca2b75997a29b6857c927bf6553da3f80ed0e4e62
+  version: 1.6.0
+  resolution: "sax@npm:1.6.0"
+  checksum: 10c0/e5593f4a91eb25761a688c4d96902e4e95a0dd6017bc65146b6f21236e3d715cf893333b76bc758923c9574c2fb5a7a76c3a81e96ea15432f2624f906c027c1e
   languageName: node
   linkType: hard
 
@@ -14586,7 +14507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.7.3, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.2, semver@npm:^7.7.3":
+"semver@npm:7.7.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -14613,30 +14534,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"send@npm:0.19.0":
-  version: 0.19.0
-  resolution: "send@npm:0.19.0"
-  dependencies:
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    etag: "npm:~1.8.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
-    mime: "npm:1.6.0"
-    ms: "npm:2.1.3"
-    on-finished: "npm:2.4.1"
-    range-parser: "npm:~1.2.1"
-    statuses: "npm:2.0.1"
-  checksum: 10c0/ea3f8a67a8f0be3d6bf9080f0baed6d2c51d11d4f7b4470de96a5029c598a7011c497511ccc28968b70ef05508675cebff27da9151dd2ceadd60be4e6cf845e3
+"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.1.3, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
   languageName: node
   linkType: hard
 
-"send@npm:^0.19.0":
-  version: 0.19.1
-  resolution: "send@npm:0.19.1"
+"send@npm:^0.19.0, send@npm:~0.19.1":
+  version: 0.19.2
+  resolution: "send@npm:0.19.2"
   dependencies:
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
@@ -14644,14 +14553,14 @@ __metadata:
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
+    fresh: "npm:~0.5.2"
+    http-errors: "npm:~2.0.1"
     mime: "npm:1.6.0"
     ms: "npm:2.1.3"
-    on-finished: "npm:2.4.1"
+    on-finished: "npm:~2.4.1"
     range-parser: "npm:~1.2.1"
-    statuses: "npm:2.0.1"
-  checksum: 10c0/ceb859859822bf55e705b96db9a909870626d1a6bfcf62a88648b9681048a7840c0ff1f4afd7babea4ccfabff7d64a7dda68a6f6c63c255cc83f40a412a1db8e
+    statuses: "npm:~2.0.2"
+  checksum: 10c0/20c2389fe0fdf3fc499938cac598bc32272287e993c4960717381a10de8550028feadfb9076f959a3a3ebdea42e1f690e116f0d16468fa56b9fd41866d3dc267
   languageName: node
   linkType: hard
 
@@ -14663,14 +14572,14 @@ __metadata:
   linkType: hard
 
 "serve-static@npm:^1.16.2":
-  version: 1.16.2
-  resolution: "serve-static@npm:1.16.2"
+  version: 1.16.3
+  resolution: "serve-static@npm:1.16.3"
   dependencies:
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     parseurl: "npm:~1.3.3"
-    send: "npm:0.19.0"
-  checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
+    send: "npm:~0.19.1"
+  checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
   languageName: node
   linkType: hard
 
@@ -14718,7 +14627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0":
+"setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
@@ -14895,9 +14804,9 @@ __metadata:
   linkType: hard
 
 "slugify@npm:^1.3.4, slugify@npm:^1.6.6":
-  version: 1.6.6
-  resolution: "slugify@npm:1.6.6"
-  checksum: 10c0/e7e63f08f389a371d6228bc19d64ec84360bf0a538333446cc49dbbf3971751a6d180d2f31551188dd007a65ca771e69f574e0283290a7825a818e90b75ef44d
+  version: 1.6.8
+  resolution: "slugify@npm:1.6.8"
+  checksum: 10c0/1052797a5e7bc6263c6e8dc64ad41d6f5ae2fd2e3a17c2aead09ded002f10de75283ff0b4da2b04dd2fbd7fa2f38a83abeaa3ab8d29709ca68e7592edd6e90dc
   languageName: node
   linkType: hard
 
@@ -15015,9 +14924,9 @@ __metadata:
   linkType: hard
 
 "spdx-license-ids@npm:^3.0.0":
-  version: 3.0.22
-  resolution: "spdx-license-ids@npm:3.0.22"
-  checksum: 10c0/4a85e44c2ccfc06eebe63239193f526508ebec1abc7cf7bca8ee43923755636234395447c2c87f40fb672cf580a9c8e684513a676bfb2da3d38a4983684bbb38
+  version: 3.0.23
+  resolution: "spdx-license-ids@npm:3.0.23"
+  checksum: 10c0/8495620f6f2a237749cce922ea2d593a66f7885c301b1a0f5542183e7041182f27f616a8f13345cefdea0c9b3e0899328e0aa8cec100cf4f3fac4bb3bd975515
   languageName: node
   linkType: hard
 
@@ -15051,12 +14960,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssri@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "ssri@npm:13.0.0"
+"ssri@npm:^13.0.0, ssri@npm:^13.0.1":
+  version: 13.0.1
+  resolution: "ssri@npm:13.0.1"
   dependencies:
     minipass: "npm:^7.0.3"
-  checksum: 10c0/405f3a531cd98b013cecb355d63555dca42fd12c7bc6671738aaa9a82882ff41cdf0ef9a2b734ca4f9a760338f114c29d01d9238a65db3ccac27929bd6e6d4b2
+  checksum: 10c0/cf6408a18676c57ff2ed06b8a20dc64bb3e748e5c7e095332e6aecaa2b8422b1e94a739a8453bf65156a8a47afe23757ba4ab52d3ea3b62322dc40875763e17a
   languageName: node
   linkType: hard
 
@@ -15085,17 +14994,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:2.0.1":
-  version: 2.0.1
-  resolution: "statuses@npm:2.0.1"
-  checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
-  languageName: node
-  linkType: hard
-
 "statuses@npm:~1.5.0":
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
+  languageName: node
+  linkType: hard
+
+"statuses@npm:~2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
   languageName: node
   linkType: hard
 
@@ -15191,12 +15100,12 @@ __metadata:
   linkType: hard
 
 "string-width@npm:^8.1.0":
-  version: 8.1.1
-  resolution: "string-width@npm:8.1.1"
+  version: 8.2.0
+  resolution: "string-width@npm:8.2.0"
   dependencies:
-    get-east-asian-width: "npm:^1.3.0"
-    strip-ansi: "npm:^7.1.0"
-  checksum: 10c0/479841b1f7a816d04ca39c486f4c130512c1a9363b445b3424dfca88ec3e71689908e3c62a3e130c2f7037d78a65880b16655f2ba1324638b4956fcd14f28f29
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/d8915428b43519b0f494da6590dbe4491857d8a12e40250e50fc01fbb616ffd8400a436bbe25712255ee129511fe0414c49d3b6b9627e2bc3a33dcec1d2eda02
   languageName: node
   linkType: hard
 
@@ -15306,11 +15215,11 @@ __metadata:
   linkType: hard
 
 "strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0, strip-ansi@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "strip-ansi@npm:7.1.2"
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
   dependencies:
-    ansi-regex: "npm:^6.0.1"
-  checksum: 10c0/0d6d7a023de33368fd042aab0bf48f4f4077abdfd60e5393e73c7c411e85e1b3a83507c11af2e656188511475776215df9ca589b4da2295c9455cc399ce1858b
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
   languageName: node
   linkType: hard
 
@@ -15490,16 +15399,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3, tar@npm:^7.5.1, tar@npm:^7.5.2, tar@npm:^7.5.4, tar@npm:^7.5.7":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:^7.4.3, tar@npm:^7.5.1, tar@npm:^7.5.11, tar@npm:^7.5.4":
+  version: 7.5.12
+  resolution: "tar@npm:7.5.12"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/b6bb420550ef50ef23356018155e956cd83282c97b6128d8d5cfe5740c57582d806a244b2ef0bf686a74ce526babe8b8b9061527623e935e850008d86d838929
+  checksum: 10c0/3825c5974f5fde792981f47ee9ffea021ee7f4b552b7ab95eeb98e5dfadfd5a5d5861f01fb772e2e5637a41980d3c019fd6cdad1be48b462b886abd7fe0fa17c
   languageName: node
   linkType: hard
 
@@ -15518,14 +15427,14 @@ __metadata:
   linkType: hard
 
 "tempy@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "tempy@npm:3.1.0"
+  version: 3.2.0
+  resolution: "tempy@npm:3.2.0"
   dependencies:
     is-stream: "npm:^3.0.0"
     temp-dir: "npm:^3.0.0"
     type-fest: "npm:^2.12.2"
     unique-string: "npm:^3.0.0"
-  checksum: 10c0/b88e70baa8d935ba8f0e0372b59ad1a961121f098da5fb4a6e05bec98ec32a49026b553532fb75c1c102ec782fd4c6a6bde0d46cbe87013fa324451ce476fb76
+  checksum: 10c0/0653c9b36323d2f25e8d24ba32f59e8dd2a9cb49740413516d8a890bb3a4d5885b56652b7231b7cebe4a5441076e8432bd5a03a76ee038c3c1f5fbb24f8cc771
   languageName: node
   linkType: hard
 
@@ -15540,8 +15449,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.15.0":
-  version: 5.44.1
-  resolution: "terser@npm:5.44.1"
+  version: 5.46.1
+  resolution: "terser@npm:5.46.1"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.15.0"
@@ -15549,7 +15458,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10c0/ee7a76692cb39b1ed22c30ff366c33ff3c977d9bb769575338ff5664676168fcba59192fb5168ef80c7cd901ef5411a1b0351261f5eaa50decf0fc71f63bde75
+  checksum: 10c0/45ba6566af976c518ff4e140250348d606761af822e23ea28d95b30fcf60fb69d3fabd93c6fafa4085d9fe31b67207e58b8480a64370b6cca07066c434101602
   languageName: node
   linkType: hard
 
@@ -15644,9 +15553,9 @@ __metadata:
   linkType: hard
 
 "tinyexec@npm:^1.0.0, tinyexec@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "tinyexec@npm:1.0.2"
-  checksum: 10c0/1261a8e34c9b539a9aae3b7f0bb5372045ff28ee1eba035a2a059e532198fe1a182ec61ac60fa0b4a4129f0c4c4b1d2d57355b5cb9aa2d17ac9454ecace502ee
+  version: 1.0.4
+  resolution: "tinyexec@npm:1.0.4"
+  checksum: 10c0/d4a5bbcf6bdb23527a4b74c4aa566f41432167112fe76f420ec7e3a90a3ecfd3a7d944383e2719fc3987b69400f7b928daf08700d145fb527c2e80ec01e198bd
   languageName: node
   linkType: hard
 
@@ -15683,7 +15592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1":
+"toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
@@ -15873,12 +15782,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^5.2.0":
-  version: 5.4.3
-  resolution: "type-fest@npm:5.4.3"
+"type-fest@npm:^5.2.0, type-fest@npm:^5.4.4":
+  version: 5.5.0
+  resolution: "type-fest@npm:5.5.0"
   dependencies:
     tagged-tag: "npm:^1.0.0"
-  checksum: 10c0/daea168fbd24db08d0a616254d18b8b454f40be48fbe1c546693c367f65b2040a3507c5b0f8e19397633aa93f552dba38c39f8c730696a3eb07cd6fba8380b09
+  checksum: 10c0/60bf79a8df45abf99490e3204eceb5cf7f915413f8a69fb578c75cab37ddcb7d29ee21f185f0e1617323ac0b2a441e001b8dc691e220d0b087e9c29ea205538c
   languageName: node
   linkType: hard
 
@@ -15999,31 +15908,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+"undici-types@npm:~7.18.0":
+  version: 7.18.2
+  resolution: "undici-types@npm:7.18.2"
+  checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
   languageName: node
   linkType: hard
 
-"undici-types@npm:~7.16.0":
-  version: 7.16.0
-  resolution: "undici-types@npm:7.16.0"
-  checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
-  languageName: node
-  linkType: hard
-
-"undici@npm:6.23.0, undici@npm:^6.18.2, undici@npm:^6.23.0":
+"undici@npm:6.23.0":
   version: 6.23.0
   resolution: "undici@npm:6.23.0"
   checksum: 10c0/d846b3fdfd05aa6081ba1eab5db6bbc21b283042c7a43722b86d1ee2bf749d7c990ceac0c809f9a07ffd88b1b0f4c0f548a8362c035088cb1997d63abdda499c
   languageName: node
   linkType: hard
 
+"undici@npm:^6.18.2, undici@npm:^6.23.0":
+  version: 6.24.1
+  resolution: "undici@npm:6.24.1"
+  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
+  languageName: node
+  linkType: hard
+
 "undici@npm:^7.0.0":
-  version: 7.21.0
-  resolution: "undici@npm:7.21.0"
-  checksum: 10c0/ec5d7524125ac9c392a8a67b84fe4f9301936ca6b2afd7be12e73ab98726e55761dc9624ac10361d2f346e6fdaf66043381a62f7d0b565facd61bbfda975a586
+  version: 7.24.5
+  resolution: "undici@npm:7.24.5"
+  checksum: 10c0/2a836f1f6ab078fde3eeb4cc8fd5b34eeaf52cfbdf16a9bab61b7223f43f7847bcd2125d1da7c4e3f5996c528bf9f7940015d39909bab80cfbd71b855470cf21
   languageName: node
   linkType: hard
 
@@ -16079,21 +15988,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unique-filename@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "unique-filename@npm:5.0.0"
-  dependencies:
-    unique-slug: "npm:^6.0.0"
-  checksum: 10c0/afb897e9cf4c2fb622ea716f7c2bb462001928fc5f437972213afdf1cc32101a230c0f1e9d96fc91ee5185eca0f2feb34127145874975f347be52eb91d6ccc2c
-  languageName: node
-  linkType: hard
-
-"unique-slug@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "unique-slug@npm:6.0.0"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-  checksum: 10c0/da7ade4cb04eb33ad0499861f82fe95ce9c7c878b7139dc54d140ecfb6a6541c18a5c8dac16188b8b379fe62c0c1f1b710814baac910cde5f4fec06212126c6a
+"unicorn-magic@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "unicorn-magic@npm:0.4.0"
+  checksum: 10c0/cd6eff90967a5528dfa2016bdb5b38b0cd64c8558f9ba04fb5c2c23f3a232a67dfe2bfa4c45af3685d5f1a40dbac6a36d48e053f80f97ae4da1e0f6a55431685
   languageName: node
   linkType: hard
 
@@ -16136,9 +16034,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "update-browserslist-db@npm:1.1.4"
+"update-browserslist-db@npm:^1.2.0":
+  version: 1.2.3
+  resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -16146,7 +16044,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10c0/db0c9aaecf1258a6acda5e937fc27a7996ccca7a7580a1b4aa8bba6a9b0e283e5e65c49ebbd74ec29288ef083f1b88d4da13e3d4d326c1e5fc55bf72d7390702
+  checksum: 10c0/13a00355ea822388f68af57410ce3255941d5fb9b7c49342c4709a07c9f230bbef7f7499ae0ca7e0de532e79a82cc0c4edbd125f1a323a1845bf914efddf8bec
   languageName: node
   linkType: hard
 
@@ -16279,10 +16177,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-worker@npm:1.2.0":
-  version: 1.2.0
-  resolution: "web-worker@npm:1.2.0"
-  checksum: 10c0/2bec036cd4784148e2f135207c62facf4457a0f2b205d6728013b9f0d7c62404dced95fcd849478387e10c8ae636d665600bd0d99d80b18c3bb2a7f045aa20d8
+"web-worker@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "web-worker@npm:1.5.0"
+  checksum: 10c0/d42744757422803c73ca64fa51e1ce994354ace4b8438b3f740425a05afeb8df12dd5dadbf6b0839a08dbda56c470d7943c0383854c4fb1ae40ab874eb10427a
   languageName: node
   linkType: hard
 
@@ -16375,8 +16273,8 @@ __metadata:
   linkType: hard
 
 "which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19":
-  version: 1.1.19
-  resolution: "which-typed-array@npm:1.1.19"
+  version: 1.1.20
+  resolution: "which-typed-array@npm:1.1.20"
   dependencies:
     available-typed-arrays: "npm:^1.0.7"
     call-bind: "npm:^1.0.8"
@@ -16385,7 +16283,7 @@ __metadata:
     get-proto: "npm:^1.0.1"
     gopd: "npm:^1.2.0"
     has-tostringtag: "npm:^1.0.2"
-  checksum: 10c0/702b5dc878addafe6c6300c3d0af5983b175c75fcb4f2a72dfc3dd38d93cf9e89581e4b29c854b16ea37e50a7d7fca5ae42ece5c273d8060dcd603b2404bbb3f
+  checksum: 10c0/16fcdada95c8afb821cd1117f0ab50b4d8551677ac08187f21d4e444530913c9ffd2dac634f0c1183345f96344b69280f40f9a8bc52164ef409e555567c2604b
   languageName: node
   linkType: hard
 
@@ -16400,14 +16298,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "which@npm:6.0.0"
+"which@npm:^6.0.0, which@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "which@npm:6.0.1"
   dependencies:
-    isexe: "npm:^3.1.1"
+    isexe: "npm:^4.0.0"
   bin:
     node-which: bin/which.js
-  checksum: 10c0/fe9d6463fe44a76232bb6e3b3181922c87510a5b250a98f1e43a69c99c079b3f42ddeca7e03d3e5f2241bf2d334f5a7657cfa868b97c109f3870625842f4cc15
+  checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
   languageName: node
   linkType: hard
 
@@ -16520,12 +16418,11 @@ __metadata:
   linkType: hard
 
 "write-file-atomic@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "write-file-atomic@npm:7.0.0"
+  version: 7.0.1
+  resolution: "write-file-atomic@npm:7.0.1"
   dependencies:
-    imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^4.0.1"
-  checksum: 10c0/f5dd7c0324ae03b399974484fbe56363654c3884920e3c4f4d59b690596f113f60f4061a3c0aa5e6f4c22e5b9e7e0608954fd8131a916c9123b68a17ba886345
+  checksum: 10c0/69cebb64945e22928a24ae7e2a55bf54438c92d6f657c1fa5e96b7c7a50f6c022e7454ab5c259079bb35f60296242f3a21234c79320d64a8ad57675b56a2098d
   languageName: node
   linkType: hard
 
@@ -16554,8 +16451,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.12.1":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
+  version: 8.19.0
+  resolution: "ws@npm:8.19.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -16564,7 +16461,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
   languageName: node
   linkType: hard
 
@@ -16740,8 +16637,8 @@ __metadata:
   linkType: hard
 
 "zustand@npm:^5.0.11":
-  version: 5.0.11
-  resolution: "zustand@npm:5.0.11"
+  version: 5.0.12
+  resolution: "zustand@npm:5.0.12"
   peerDependencies:
     "@types/react": ">=18.0.0"
     immer: ">=9.0.6"
@@ -16756,6 +16653,6 @@ __metadata:
       optional: true
     use-sync-external-store:
       optional: true
-  checksum: 10c0/61836b48dac5978c9d1b8289d5162a151bee77828371b9aba6431a079b77faca0635ba53da3f7b331295fbc4e78318a109a4527f7a051cb63abfe79b69ccbecf
+  checksum: 10c0/304c1dfb6033d758ddc7606c15df8566e6cace83ee4eeec721e8975f7813fd4cca2c68ff6b3eaa1841a9e53f0cf8486007217479785eccb845e3596de4df7f1e
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary

- Add drag-and-drop reordering via long-press gesture — nodes can be moved above, below, or inside other nodes
- Fully customizable: style props for overlay/indicator, or provide entirely custom components
- Auto-scroll near edges, auto-expand collapsed nodes on hover, invalid target prevention (no dropping onto own
descendants)
- Checked/indeterminate states automatically recalculated after every move
- `moveTreeNode` utility exported for manual tree manipulation
- 4 example screens showcasing basic usage, styled indicators, custom components, and custom row integration
- Contributors section added to release notes template

## Breaking Changes

`NodeRowProps` extended with `isDragTarget`, `isDragging`, `isDraggedNode` — custom row components may want to
handle these new props for drag state visual feedback.

## New Props

| Prop | Description |
|------|-------------|
| `dragEnabled` | Enable drag-and-drop reordering |
| `onDragEnd` | Callback with `DragEndEvent` (includes `newTreeData`) |
| `longPressDuration` | Ms before drag starts (default: 400) |
| `autoScrollThreshold` | Px from edge to auto-scroll (default: 60) |
| `autoScrollSpeed` | Speed multiplier (default: 1.0) |
| `dragOverlayOffset` | Overlay offset in item-height units (default: -1) |
| `autoExpandDelay` | Ms before auto-expanding hovered node (default: 800) |
| `dragDropCustomizations` | Overlay styles, indicator styles, or custom components |

## Test Coverage

115 tests pass (24 new covering moveTreeNode, store drag state, and recalculateCheckedStates). Lint clean, typecheck
  passes, library builds.

Closes #41, closes #99